### PR TITLE
migration helpers

### DIFF
--- a/lib/ardb.rb
+++ b/lib/ardb.rb
@@ -13,6 +13,12 @@ module Ardb
     if !self.config.required_set?
       raise RuntimeError, "Missing required configuration values"
     end
+
+    # setup AR
+
+    if defined?(ActiveRecord::Migration::CommandRecorder)
+      ActiveRecord::Migration::CommandRecorder.send(:include, Ardb::MigrationHelpers::RecorderMixin)
+    end
     ActiveRecord::Base.establish_connection(self.config.db.to_hash)
   end
 

--- a/lib/ardb/migration_helpers.rb
+++ b/lib/ardb/migration_helpers.rb
@@ -1,0 +1,92 @@
+require 'ardb'
+
+module Ardb; end
+module Ardb::MigrationHelpers
+
+  def foreign_key(from_table, from_column, to_table, options={})
+    fk = ForeignKey.new(from_table, from_column, to_table, options)
+    execute(fk.add_sql)
+  end
+
+  def drop_foreign_key(*args)
+    from_table, from_column = args[0..1]
+    options = args.last.kind_of?(Hash) ? args.last : {}
+    fk = ForeignKey.new(from_table, from_column, nil, options)
+    execute(fk.drop_sql)
+  end
+
+  def remove_column_with_fk(table, column)
+    drop_foreign_key(table, column)
+    remove_column(table, column)
+  end
+
+  class ForeignKey
+    attr_reader :from_table, :from_column, :to_table, :to_column, :name,
+                :adapter
+
+    def initialize(from_table, from_column, to_table, options=nil)
+      options ||= {}
+      @from_table  = from_table
+      @from_column = from_column
+      @to_table    = to_table
+      @to_column   = (options[:to_column] || 'id')
+      @name        = (options[:name] || "fk_#{@from_table}_#{@from_column}")
+      @adapter     = Ardb.config.db.adapter
+    end
+
+    def add_sql
+      self.send("#{self.adapter}_add_sql")
+    end
+
+    def drop_sql
+      self.send("#{self.adapter}_drop_sql")
+    end
+
+    protected
+
+    def postgresql_add_sql
+      "ALTER TABLE #{self.from_table}"\
+      " ADD CONSTRAINT #{self.name}"\
+      " FOREIGN KEY (#{self.from_column})"\
+      " REFERENCES #{self.to_table} (#{self.to_column})"
+    end
+
+    def postgresql_drop_sql
+      "ALTER TABLE #{self.from_table}"\
+      " DROP CONSTRAINT #{self.name}"
+    end
+
+    def mysql_add_sql
+      "ALTER TABLE #{self.from_table}"\
+      " ADD CONSTRAINT #{self.name}"\
+      " FOREIGN KEY (#{self.from_column})"\
+      " REFERENCES #{self.to_table} (#{self.to_column})"
+    end
+    alias :mysql2_add_sql :mysql_add_sql
+
+    def mysql_drop_sql
+      "ALTER TABLE #{self.from_table}"\
+      " DROP FOREIGN KEY #{self.name}"
+    end
+    alias :mysql2_drop_sql :mysql_drop_sql
+
+  end
+
+  # This file will setup the AR migration command recorder for being able to change our
+  # stuff, require it in an initializer
+
+  module RecorderMixin
+
+    def foreign_key(*args)
+      record(:foreign_key, args)
+    end
+
+    protected
+
+    def invert_foreign_key(args)
+      [ :drop_foreign_key, args ]
+    end
+
+  end
+
+end

--- a/test/support/with_migration_helpers.rb
+++ b/test/support/with_migration_helpers.rb
@@ -1,0 +1,10 @@
+require 'ardb/migration_helpers'
+
+module Ardb
+
+  class WithMigrationHelpers
+    include Ardb::MigrationHelpers
+
+  end
+
+end

--- a/test/unit/migration_helpers_tests.rb
+++ b/test/unit/migration_helpers_tests.rb
@@ -1,0 +1,76 @@
+require 'assert'
+require 'test/support/with_migration_helpers'
+require 'ardb/migration_helpers'
+
+module Ardb::MigrationHelpers
+
+  class BaseTests < Assert::Context
+    desc "Ardb migration helpers"
+    setup do
+      @with = Ardb::WithMigrationHelpers.new
+    end
+    subject{ @with }
+
+    should have_instance_methods :foreign_key, :drop_foreign_key, :remove_column_with_fk
+
+  end
+
+  class ForeignKeyTests < BaseTests
+    desc "ForeignKey handler"
+    setup do
+      @fk = ForeignKey.new('fromtbl', 'fromcol', 'totbl')
+    end
+    subject{ @fk }
+
+    should have_readers :from_table, :from_column, :to_table, :to_column
+    should have_readers :name, :adapter
+    should have_instance_methods :add_sql, :drop_sql
+
+    should "know its from table/column and to table" do
+      assert_equal 'fromtbl', subject.from_table
+      assert_equal 'fromcol', subject.from_column
+      assert_equal 'totbl',   subject.to_table
+    end
+
+    should "default its to column" do
+      assert_equal 'id', subject.to_column
+    end
+
+    should "default its name" do
+      exp_name = "fk_fromtbl_fromcol"
+      assert_equal exp_name, subject.name
+    end
+
+    should "use Ardb's config db adapter" do
+      assert_equal Ardb.config.db.adapter, subject.adapter
+    end
+
+    should "support the `postgresql` adapter" do
+      exp_add_sql = "ALTER TABLE fromtbl"\
+                    " ADD CONSTRAINT fk_fromtbl_fromcol"\
+                    " FOREIGN KEY (fromcol)"\
+                    " REFERENCES totbl (id)"
+      assert_equal exp_add_sql, subject.send('postgresql_add_sql')
+
+      exp_drop_sql = "ALTER TABLE fromtbl"\
+                     " DROP CONSTRAINT fk_fromtbl_fromcol"
+      assert_equal exp_drop_sql, subject.send('postgresql_drop_sql')
+    end
+
+    should "support the `mysql` and `mysql2` adapters" do
+      exp_add_sql = "ALTER TABLE fromtbl"\
+                    " ADD CONSTRAINT fk_fromtbl_fromcol"\
+                    " FOREIGN KEY (fromcol)"\
+                    " REFERENCES totbl (id)"
+      assert_equal exp_add_sql, subject.send('mysql_add_sql')
+      assert_equal exp_add_sql, subject.send('mysql2_add_sql')
+
+      exp_drop_sql = "ALTER TABLE fromtbl"\
+                     " DROP FOREIGN KEY fk_fromtbl_fromcol"
+      assert_equal exp_drop_sql, subject.send('mysql_drop_sql')
+      assert_equal exp_drop_sql, subject.send('mysql2_drop_sql')
+    end
+
+  end
+
+end


### PR DESCRIPTION
This adds a bunch of migration helpers for AR, mostly related to
foreign keying.

@jcredding ready for review.  so coverage holes but I see little value in covering them - AR does most of it.  any problems with this?
