### PR TITLE
ardb cli bin and command framework

### DIFF
--- a/bin/ardb
+++ b/bin/ardb
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+#
+# Copyright (c) 2011-Present Kelly Redding and Collin Redding
+#
+
+require 'ardb/cli'
+Ardb::CLI.run *ARGV

--- a/lib/ardb/cli.rb
+++ b/lib/ardb/cli.rb
@@ -1,0 +1,107 @@
+require 'ardb/version'
+require 'ardb/runner'
+
+module Ardb
+
+  class CLI
+
+    def self.run(*args)
+      self.new.run(*args)
+    end
+
+    def initialize
+      @cli = CLIRB.new do
+        option 'root_path', 'root path Ardb should use (`Dir.pwd`)', {
+          :abbrev => 'p', :value => String
+        }
+      end
+    end
+
+    def run(*args)
+      begin
+        @cli.parse!(args)
+        Ardb::Runner.new(@cli.args, @cli.opts).run
+      rescue Ardb::Runner::UnknownCmdError => err
+        puts "#{err.message}\n\n"
+        puts help
+      rescue CLIRB::HelpExit
+        puts help
+      rescue CLIRB::VersionExit
+        puts Ardb::VERSION
+      rescue CLIRB::Error => exception
+        puts "#{exception.message}\n\n"
+        puts help
+        exit(1)
+      rescue Exception => exception
+        puts "#{exception.class}: #{exception.message}"
+        puts exception.backtrace.join("\n")
+        exit(1)
+      end
+      exit(0)
+    end
+
+    def help
+      "Usage: ardb [options] COMMAND\n"\
+      "\n"\
+      "Options:"\
+      "#{@cli}"
+    end
+
+  end
+
+  class CLIRB  # Version 1.0.0, https://github.com/redding/cli.rb
+    Error    = Class.new(RuntimeError);
+    HelpExit = Class.new(RuntimeError); VersionExit = Class.new(RuntimeError)
+    attr_reader :argv, :args, :opts, :data
+
+    def initialize(&block)
+      @options = []; instance_eval(&block) if block
+      require 'optparse'
+      @data, @args, @opts = [], [], {}; @parser = OptionParser.new do |p|
+        p.banner = ''; @options.each do |o|
+          @opts[o.name] = o.value; p.on(*o.parser_args){ |v| @opts[o.name] = v }
+        end
+        p.on_tail('--version', ''){ |v| raise VersionExit, v.to_s }
+        p.on_tail('--help',    ''){ |v| raise HelpExit,    v.to_s }
+      end
+    end
+
+    def option(*args); @options << Option.new(*args); end
+    def parse!(argv)
+      @args = (argv || []).dup.tap do |args_list|
+        begin; @parser.parse!(args_list)
+        rescue OptionParser::ParseError => err; raise Error, err.message; end
+      end; @data = @args + [@opts]
+    end
+    def to_s; @parser.to_s; end
+    def inspect
+      "#<#{self.class}:#{'0x0%x' % (object_id << 1)} @data=#{@data.inspect}>"
+    end
+
+    class Option
+      attr_reader :name, :opt_name, :desc, :abbrev, :value, :klass, :parser_args
+
+      def initialize(name, *args)
+        settings, @desc = args.last.kind_of?(::Hash) ? args.pop : {}, args.pop || ''
+        @name, @opt_name, @abbrev = parse_name_values(name, settings[:abbrev])
+        @value, @klass = gvalinfo(settings[:value])
+        @parser_args = if [TrueClass, FalseClass, NilClass].include?(@klass)
+          ["-#{@abbrev}", "--[no-]#{@opt_name}", @desc]
+        else
+          ["-#{@abbrev}", "--#{@opt_name} #{@opt_name.upcase}", @klass, @desc]
+        end
+      end
+
+      private
+
+      def parse_name_values(name, custom_abbrev)
+        [ (processed_name = name.to_s.strip.downcase), processed_name.gsub('_', '-'),
+          custom_abbrev || processed_name.gsub(/[^a-z]/, '').chars.first || 'a'
+        ]
+      end
+      def gvalinfo(v); v.kind_of?(Class) ? [nil,gklass(v)] : [v,gklass(v.class)]; end
+      def gklass(k); k == Fixnum ? Integer : k; end
+    end
+  end
+
+end

--- a/lib/ardb/runner.rb
+++ b/lib/ardb/runner.rb
@@ -1,0 +1,34 @@
+require 'ardb'
+
+module Ardb; end
+class Ardb::Runner
+  UnknownCmdError = Class.new(ArgumentError)
+
+  attr_reader :cmd, :cmd_args, :opts
+
+  def initialize(args, opts)
+    @opts = opts
+    @cmd = args.shift || ""
+    @cmd_args = args
+
+    @opts['root_path'] ||= Dir.pwd
+  end
+
+  def run
+    Ardb.config.root_path = opts.delete('root_path')
+
+    case @cmd
+    when 'null'
+      NullCommand.new.run
+    else
+      raise UnknownCmdError, "Unknown command `#{@cmd}`"
+    end
+  end
+
+  class NullCommand
+    def run
+      # if this was a real command it would do something here
+    end
+  end
+
+end

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -1,0 +1,45 @@
+require 'assert'
+require 'pathname'
+require 'ardb/runner'
+
+class Ardb::Runner
+
+  class BaseTests < Assert::Context
+    desc "Ardb::Runner"
+    setup do
+      @runner = Ardb::Runner.new(['null', 1, 2], 'some' => 'opts')
+    end
+    subject{ @runner }
+
+    should have_readers :cmd, :cmd_args, :opts
+
+    should "know its cmd, cmd_args, and opts" do
+      assert_equal 'null', subject.cmd
+      assert_equal [1,2],  subject.cmd_args
+      assert_equal 'opts', subject.opts['some']
+    end
+
+    should "default the 'root_path' opt to `Dir.pwd`" do
+      assert_equal Dir.pwd, subject.opts['root_path']
+    end
+
+  end
+
+  class RunTests < BaseTests
+    desc "when running a command"
+    setup do
+      @orig_root_path = Ardb.config.root_path
+      @runner = Ardb::Runner.new(['null', 1, 2], 'root_path' => '/some/path')
+      @runner.run
+    end
+    teardown do
+      Ardb.config.root_path = @orig_root_path
+    end
+
+    should "set the Ardb config root_path" do
+      assert_equal Pathname.new('/some/path'), Ardb.config.root_path
+    end
+
+  end
+
+end


### PR DESCRIPTION
This will allow us to define db commands and have a nice CLI for
invoking them.  This doesn't define any commands, just the CLI and
the framework for adding new commands.

Also, the main reason for having a CLI and not using `rake` is b/c Rake is a ghetto.

@jcredding ready for review.
