### PR TITLE
migrate sub-command

### DIFF
--- a/lib/ardb/runner.rb
+++ b/lib/ardb/runner.rb
@@ -4,24 +4,26 @@ module Ardb; end
 class Ardb::Runner
   UnknownCmdError = Class.new(ArgumentError)
 
-  attr_reader :cmd, :cmd_args, :opts
+  attr_reader :cmd_name, :cmd_args, :opts, :root_path
 
   def initialize(args, opts)
     @opts = opts
-    @cmd = args.shift || ""
+    @cmd_name = args.shift || ""
     @cmd_args = args
-
-    @opts['root_path'] ||= Dir.pwd
+    @root_path = @opts.delete('root_path') || Dir.pwd
   end
 
   def run
-    Ardb.config.root_path = opts.delete('root_path')
-
-    case @cmd
+    Ardb.config.root_path = @root_path
+    # TODO: require in a standard file, like config/db.rb??? (for initialization purposes)
+    case @cmd_name
+    when 'migrate'
+      require 'ardb/runner/migrate_command'
+      MigrateCommand.new.run
     when 'null'
       NullCommand.new.run
     else
-      raise UnknownCmdError, "Unknown command `#{@cmd}`"
+      raise UnknownCmdError, "Unknown command `#{@cmd_name}`"
     end
   end
 

--- a/lib/ardb/runner/migrate_command.rb
+++ b/lib/ardb/runner/migrate_command.rb
@@ -1,0 +1,28 @@
+require 'active_record'
+require 'ardb/runner'
+
+class Ardb::Runner::MigrateCommand
+
+  attr_reader :migrations_path, :schema_file_path, :version, :verbose
+
+  def initialize
+    @migrations_path = Ardb.config.migrations_path
+    @schema_file_path = Ardb.config.schema_path
+    @version = ENV["VERSION"] ? ENV["VERSION"].to_i : nil
+    @verbose = ENV["VERBOSE"] ? ENV["VERBOSE"] == "true" : true
+  end
+
+  def run
+    ActiveRecord::Migrator.migrations_path = @migrations_path
+    ActiveRecord::Migration.verbose = @verbose
+    ActiveRecord::Migrator.migrate(@migrations_path, @version) do |migration|
+      ENV["SCOPE"].blank? || (ENV["SCOPE"] == migration.scope)
+    end
+
+    require 'active_record/schema_dumper'
+    File.open(@schema_file_path, "w:utf-8") do |file|
+      ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection, file)
+    end
+  end
+
+end

--- a/test/unit/runner/migrate_command_tests.rb
+++ b/test/unit/runner/migrate_command_tests.rb
@@ -1,0 +1,65 @@
+require 'assert'
+require 'ardb/runner/migrate_command'
+
+class Ardb::Runner::MigrateCommand
+
+  class BaseTests < Assert::Context
+    desc "Ardb::Runner::MigrateCommand"
+    setup do
+      @cmd = Ardb::Runner::MigrateCommand.new
+    end
+    subject{ @cmd }
+
+    should have_readers :migrations_path, :schema_file_path, :version, :verbose
+
+    should "use the config's migrations and schema file paths" do
+      assert_equal Ardb.config.migrations_path, subject.migrations_path
+      assert_equal Ardb.config.schema_path, subject.schema_file_path
+    end
+
+    should "not target a specific version by default" do
+      assert_nil subject.version
+    end
+
+    should "be verbose by default" do
+      assert subject.verbose
+    end
+
+  end
+
+  class VersionTests < BaseTests
+    desc "with a version ENV setting"
+    setup do
+      ENV["VERSION"] = '12345'
+      @cmd = Ardb::Runner::MigrateCommand.new
+    end
+    teardown do
+      ENV["VERSION"] = nil
+    end
+
+    should "should target the given version" do
+      assert_equal 12345, subject.version
+    end
+
+  end
+
+  class VerboseTests < BaseTests
+    desc "with a verbose ENV setting"
+    setup do
+      ENV["VERBOSE"] = 'no'
+      @cmd = Ardb::Runner::MigrateCommand.new
+    end
+    teardown do
+      ENV["VERBOSE"] = nil
+    end
+
+    should "turn off verbose mode if not set to 'true'" do
+      assert_not subject.verbose
+    end
+
+  end
+
+  # TODO: would be nice to have a system test that actually took some migrations
+  # and ran them.
+
+end

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -11,16 +11,16 @@ class Ardb::Runner
     end
     subject{ @runner }
 
-    should have_readers :cmd, :cmd_args, :opts
+    should have_readers :cmd_name, :cmd_args, :opts, :root_path
 
     should "know its cmd, cmd_args, and opts" do
-      assert_equal 'null', subject.cmd
+      assert_equal 'null', subject.cmd_name
       assert_equal [1,2],  subject.cmd_args
       assert_equal 'opts', subject.opts['some']
     end
 
     should "default the 'root_path' opt to `Dir.pwd`" do
-      assert_equal Dir.pwd, subject.opts['root_path']
+      assert_equal Dir.pwd, subject.root_path
     end
 
   end


### PR DESCRIPTION
This adds a `migrate` subcommand to run migrations.  It expects
the migrations and schema paths have already been configured.

This also includes some tweaks to the Runner class to better handle
the `root_path` and Ardb configuration needs.

Closes #4.

@jcredding ready for review.
