### PR TITLE
create subcommand

### DIFF
--- a/lib/ardb/runner.rb
+++ b/lib/ardb/runner.rb
@@ -20,6 +20,9 @@ class Ardb::Runner
     when 'migrate'
       require 'ardb/runner/migrate_command'
       MigrateCommand.new.run
+    when 'create'
+      require 'ardb/runner/create_command'
+      CreateCommand.new.run
     when 'null'
       NullCommand.new.run
     else

--- a/lib/ardb/runner/create_command.rb
+++ b/lib/ardb/runner/create_command.rb
@@ -1,0 +1,39 @@
+require 'active_record'
+require 'ardb/runner'
+
+# Note: currently only postgresql adapter supported
+
+class Ardb::Runner::CreateCommand
+
+  def run
+    begin
+      self.send("#{Ardb.config.db.adapter}_cmd").run
+    rescue Exception => e
+      $stderr.puts e, *(e.backtrace)
+      $stderr.puts "Couldn't create database for #{Ardb.config.db.inspect}"
+    end
+  end
+
+  def postgresql_cmd
+    PostgresqlCommand.new.run
+  end
+
+  class PostgresqlCommand
+    attr_reader :config_settings, :database
+
+    def initialize
+      @config_settings  = Ardb.config.db.to_hash
+      @database = Ardb.config.db.database
+    end
+
+    def run
+      ActiveRecord::Base.establish_connection(@config_settings.merge({
+        :database           => 'postgres',
+        :schema_search_path => 'public'
+      }))
+      ActiveRecord::Base.connection.create_database(@database, @config_settings)
+      ActiveRecord::Base.establish_connection(@config_settings)
+    end
+  end
+
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -8,7 +8,17 @@ $LOAD_PATH.unshift(ROOT_PATH)
 # require pry for debugging (`binding.pry`)
 require 'pry'
 
+require 'fileutils'
+TESTDB_PATH = File.join(ROOT_PATH, 'tmp', 'testdb')
+FileUtils.mkdir_p TESTDB_PATH
+
 require 'ardb'
 Ardb.configure do |c|
-  c.root_path = ROOT_PATH
+  c.root_path = TESTDB_PATH
+
+  c.db.adapter  'postgresql' #'sqlite3'
+  c.db.database 'ardbtest'   #'db/development.sqlite3'
+  c.db.pool     5
+  c.db.timeout  5000
+
 end

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -14,12 +14,12 @@ class Ardb::Config
     should have_options :migrations_path, :schema_path
 
     should "should use `db/migrations` as the default migrations path" do
-      exp_path = Pathname.new(ROOT_PATH).join("db/migrations").to_s
+      exp_path = Pathname.new(TESTDB_PATH).join("db/migrations").to_s
       assert_equal exp_path, subject.migrations_path
     end
 
     should "should use `db/schema.rb` as the default schema path" do
-      exp_path = Pathname.new(ROOT_PATH).join("db/schema.rb").to_s
+      exp_path = Pathname.new(TESTDB_PATH).join("db/schema.rb").to_s
       assert_equal exp_path, subject.schema_path
     end
 

--- a/test/unit/runner/create_command_tests.rb
+++ b/test/unit/runner/create_command_tests.rb
@@ -1,0 +1,37 @@
+require 'assert'
+require 'ardb/runner/create_command'
+
+class Ardb::Runner::CreateCommand
+
+  class BaseTests < Assert::Context
+    desc "Ardb::Runner::CreateCommand"
+    setup do
+      @cmd = Ardb::Runner::CreateCommand.new
+    end
+    subject{ @cmd }
+
+    should have_instance_methods :run, :postgresql_cmd
+
+  end
+
+  class PostgresqlTests < BaseTests
+    desc "Ardb::Runner::CreateCommand::PostgresqlCommand"
+    setup do
+      @cmd = Ardb::Runner::CreateCommand::PostgresqlCommand.new
+    end
+
+    should have_readers :config_settings, :database
+
+    should "use the config's db settings " do
+      assert_equal Ardb.config.db.to_hash, subject.config_settings
+    end
+
+    should "use the config's database" do
+      assert_equal Ardb.config.db.database, subject.database
+    end
+
+  end
+
+  # TODO: would be nice to have a system test that actually created a db
+
+end


### PR DESCRIPTION
This adds a cli subcommand to create a database based on the config.
This also reworks the test helper to do some configuration b/c this
command requires a bit of configuration to be in place.

This is only the start and this needs further work at some point.
Some system tests would be nice and it would be good to expand it
to support mysql/mysql2 and sqlite3.

Closes #7.
