### PR TITLE
drop subcommand

### DIFF
--- a/lib/ardb/runner.rb
+++ b/lib/ardb/runner.rb
@@ -23,6 +23,9 @@ class Ardb::Runner
     when 'create'
       require 'ardb/runner/create_command'
       CreateCommand.new.run
+    when 'drop'
+      require 'ardb/runner/drop_command'
+      DropCommand.new.run
     when 'null'
       NullCommand.new.run
     else

--- a/lib/ardb/runner/drop_command.rb
+++ b/lib/ardb/runner/drop_command.rb
@@ -1,0 +1,38 @@
+require 'active_record'
+require 'ardb/runner'
+
+# Note: currently only postgresql adapter supported
+
+class Ardb::Runner::DropCommand
+
+  def run
+    begin
+      self.send("#{Ardb.config.db.adapter}_cmd").run
+    rescue Exception => e
+      $stderr.puts e, *(e.backtrace)
+      $stderr.puts "Couldn't drop database for #{Ardb.config.db.inspect}"
+    end
+  end
+
+  def postgresql_cmd
+    PostgresqlCommand.new.run
+  end
+
+  class PostgresqlCommand
+    attr_reader :config_settings, :database
+
+    def initialize
+      @config_settings  = Ardb.config.db.to_hash
+      @database = Ardb.config.db.database
+    end
+
+    def run
+      ActiveRecord::Base.establish_connection(@config_settings.merge({
+        :database           => 'postgres',
+        :schema_search_path => 'public'
+      }))
+      ActiveRecord::Base.connection.drop_database(@database)
+    end
+  end
+
+end

--- a/test/unit/runner/drop_command_tests.rb
+++ b/test/unit/runner/drop_command_tests.rb
@@ -1,0 +1,37 @@
+require 'assert'
+require 'ardb/runner/drop_command'
+
+class Ardb::Runner::DropCommand
+
+  class BaseTests < Assert::Context
+    desc "Ardb::Runner::DropCommand"
+    setup do
+      @cmd = Ardb::Runner::DropCommand.new
+    end
+    subject{ @cmd }
+
+    should have_instance_methods :run, :postgresql_cmd
+
+  end
+
+  class PostgresqlTests < BaseTests
+    desc "Ardb::Runner::DropCommand::PostgresqlCommand"
+    setup do
+      @cmd = Ardb::Runner::DropCommand::PostgresqlCommand.new
+    end
+
+    should have_readers :config_settings, :database
+
+    should "use the config's db settings " do
+      assert_equal Ardb.config.db.to_hash, subject.config_settings
+    end
+
+    should "use the config's database" do
+      assert_equal Ardb.config.db.database, subject.database
+    end
+
+  end
+
+  # TODO: would be nice to have a system test that actually created a db
+
+end


### PR DESCRIPTION
This adds a subcommand to drop the current db.  Only postgres adapter
supported right now.

Closes #8.

@jcredding ready for review.  I fear that some future refactors may be in order when I bring on other adapters.  For now, this should work though.
