### PR TITLE
model each adapter

### DIFF
--- a/lib/ardb.rb
+++ b/lib/ardb.rb
@@ -1,6 +1,7 @@
 require 'active_record'
 require 'ns-options'
 require 'pathname'
+require 'singleton'
 
 require "ardb/version"
 
@@ -10,6 +11,8 @@ module Ardb
   def self.config; Config; end
   def self.configure(&block); Config.define(&block); end
 
+  def self.adapter; Adapter.current; end
+
   def self.validate!
     if !self.config.required_set?
       raise NotConfiguredError, "missing required configs"
@@ -18,6 +21,7 @@ module Ardb
 
   def self.init
     validate!
+    Adapter.init
 
     # setup AR
     ActiveRecord::Base.establish_connection(self.config.db.to_hash)
@@ -41,6 +45,48 @@ module Ardb
 
     def self.default_migrations_path; root_path.join("db/migrations"); end
     def self.default_schema_path;     root_path.join("db/schema.rb");  end
+
+  end
+
+  class Adapter
+    include Singleton
+
+    attr_reader :current
+
+    def init
+      @current = Adapter.send(Ardb.config.db.adapter)
+    end
+
+    def reset
+      @current = nil
+    end
+
+    def sqlite
+      require 'ardb/adapter/sqlite'
+      Adapter::Sqlite.new
+    end
+    alias_method :sqlite3, :sqlite
+
+    def postgresql
+      require 'ardb/adapter/postgresql'
+      Adapter::Postgresql.new
+    end
+
+    def mysql
+      require 'ardb/adapter/mysql'
+      Adapter::Mysql.new
+    end
+    alias_method :mysql2, :mysql
+
+    # nice singleton api
+
+    def self.method_missing(method, *args, &block)
+      self.instance.send(method, *args, &block)
+    end
+
+    def self.respond_to?(method)
+      super || self.instance.respond_to?(method)
+    end
 
   end
 

--- a/lib/ardb/adapter/base.rb
+++ b/lib/ardb/adapter/base.rb
@@ -1,0 +1,8 @@
+module Ardb; end
+class Ardb::Adapter; end
+class Ardb::Adapter::Base
+
+  def initialize
+  end
+
+end

--- a/lib/ardb/adapter/mysql.rb
+++ b/lib/ardb/adapter/mysql.rb
@@ -1,0 +1,10 @@
+require 'ardb'
+require 'ardb/adapter/base'
+
+class Ardb::Adapter
+
+  class Mysql < Base
+
+  end
+
+end

--- a/lib/ardb/adapter/postgresql.rb
+++ b/lib/ardb/adapter/postgresql.rb
@@ -1,0 +1,10 @@
+require 'ardb'
+require 'ardb/adapter/base'
+
+class Ardb::Adapter
+
+  class Postgresql < Base
+
+  end
+
+end

--- a/lib/ardb/adapter/sqlite.rb
+++ b/lib/ardb/adapter/sqlite.rb
@@ -1,0 +1,10 @@
+require 'ardb'
+require 'ardb/adapter/base'
+
+class Ardb::Adapter
+
+  class Sqlite < Base
+
+  end
+
+end

--- a/lib/ardb/runner.rb
+++ b/lib/ardb/runner.rb
@@ -40,9 +40,9 @@ class Ardb::Runner
 
   def setup_run
     Ardb.config.root_path = @root_path
-    # TODO: require in a standard file, like config/db.rb??? (for initialization purposes)
     DbConfigFile.new.require_if_exists
     Ardb.validate!
+    Ardb::Adapter.init
   end
 
   class DbConfigFile

--- a/test/unit/adapter/base_tests.rb
+++ b/test/unit/adapter/base_tests.rb
@@ -1,0 +1,19 @@
+require 'assert'
+require 'ardb/adapter/base'
+
+class Ardb::Adapter::Base
+
+  class BaseTests < Assert::Context
+    desc "Ardb::Adapter::Base"
+    setup do
+      @adapter = Ardb::Adapter::Base.new
+    end
+    subject { @adapter }
+
+    should "test stuff" do
+      skip 'TODO tests'
+    end
+
+  end
+
+end

--- a/test/unit/adapter/mysql_tests.rb
+++ b/test/unit/adapter/mysql_tests.rb
@@ -1,0 +1,19 @@
+require 'assert'
+require 'ardb/adapter/mysql'
+
+class Ardb::Adapter::Mysql
+
+  class BaseTests < Assert::Context
+    desc "Ardb::Adapter::Mysql"
+    setup do
+      @adapter = Ardb::Adapter::Mysql.new
+    end
+    subject { @adapter }
+
+    should "test stuff" do
+      skip 'TODO tests'
+    end
+
+  end
+
+end

--- a/test/unit/adapter/postgresql_tests.rb
+++ b/test/unit/adapter/postgresql_tests.rb
@@ -1,0 +1,19 @@
+require 'assert'
+require 'ardb/adapter/postgresql'
+
+class Ardb::Adapter::Postgresql
+
+  class BaseTests < Assert::Context
+    desc "Ardb::Adapter::Postgresql"
+    setup do
+      @adapter = Ardb::Adapter::Postgresql.new
+    end
+    subject { @adapter }
+
+    should "test stuff" do
+      skip 'TODO tests'
+    end
+
+  end
+
+end

--- a/test/unit/adapter/sqlite_tests.rb
+++ b/test/unit/adapter/sqlite_tests.rb
@@ -1,0 +1,19 @@
+require 'assert'
+require 'ardb/adapter/sqlite'
+
+class Ardb::Adapter::Sqlite
+
+  class BaseTests < Assert::Context
+    desc "Ardb::Adapter::Sqlite"
+    setup do
+      @adapter = Ardb::Adapter::Sqlite.new
+    end
+    subject { @adapter }
+
+    should "test stuff" do
+      skip 'TODO tests'
+    end
+
+  end
+
+end

--- a/test/unit/ardb_tests.rb
+++ b/test/unit/ardb_tests.rb
@@ -6,8 +6,11 @@ module Ardb
   class BaseTests < Assert::Context
     desc "Ardb"
     subject{ Ardb }
+    teardown do
+      Adapter.reset
+    end
 
-    should have_instance_methods :config, :configure, :validate!, :init
+    should have_imeths :config, :configure, :adapter, :validate!, :init
 
     should "return its `Config` class with the `config` method" do
       assert_same Config, subject.config
@@ -20,12 +23,25 @@ module Ardb
       Ardb.config.db.adapter = orig_adapter
     end
 
-    should "establish and AR connection if all configs are set" do
-      assert true
-      # not going to test this b/c I don't want to bring in all the crap it
-      # takes to actually establish a connection with AR (adapters, etc)
-      # plus, most of this should be handled by AR, ns-options, and the above
-      # tests anyway
+    should "init the adapter on init" do
+      assert_nil Adapter.current
+      begin
+        subject.init
+      rescue LoadError
+      end
+
+      assert_not_nil Adapter.current
+      assert_same Adapter.current, subject.adapter
+    end
+
+    should "establish an AR connection on init" do
+      assert_raises(LoadError) do
+        # not going to test this b/c I don't want to bring in all the crap it
+        # takes to actually establish a connection with AR (adapters, etc)
+        # plus, most of this should be handled by AR, ns-options, and the above
+        # tests anyway
+        subject.init
+      end
     end
 
   end

--- a/test/unit/runner/create_command_tests.rb
+++ b/test/unit/runner/create_command_tests.rb
@@ -64,6 +64,4 @@ class Ardb::Runner::CreateCommand
 
   end
 
-  # TODO: would be nice to have a system test that actually created a db
-
 end

--- a/test/unit/runner/drop_command_tests.rb
+++ b/test/unit/runner/drop_command_tests.rb
@@ -55,6 +55,4 @@ class Ardb::Runner::DropCommand
 
   end
 
-  # TODO: would be nice to have a system test that actually created a db
-
 end

--- a/test/unit/runner/generate_command_tests.rb
+++ b/test/unit/runner/generate_command_tests.rb
@@ -41,6 +41,4 @@ class Ardb::Runner::GenerateCommand
 
   end
 
-  # TODO: would be nice to have a system test
-
 end

--- a/test/unit/runner/migrate_command_tests.rb
+++ b/test/unit/runner/migrate_command_tests.rb
@@ -59,7 +59,4 @@ class Ardb::Runner::MigrateCommand
 
   end
 
-  # TODO: would be nice to have a system test that actually took some migrations
-  # and ran them.
-
 end

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -33,6 +33,7 @@ class Ardb::Runner
     end
     teardown do
       Ardb.config.root_path = @orig_root_path
+      Ardb::Adapter.reset
     end
 
     should "set the Ardb config root_path" do
@@ -45,6 +46,12 @@ class Ardb::Runner
       Ardb.config.db.adapter = nil
       assert_raises(Ardb::NotConfiguredError) { subject.run }
       Ardb.config.db.adapter = orig_adapter
+    end
+
+    should "init the adapter" do
+      assert_nil Ardb.adapter
+      subject.run
+      assert_not_nil Ardb.adapter
     end
 
     should "complain about unknown cmds" do


### PR DESCRIPTION
This adds adapter modeling and stubs out handling.  Now, Ardb tracks
a current adapter (based on the config) and the adapter will contain
all of the behavior specific to it.

The motivation here is to reduce duplication and to centralize the
behavior that is most likely to change over time.

In future PRs, I'll switch each piece to using the adapters.

@jcredding ready for review.  Just a bunch of setup here, but I wanted to do this separately to not junk up the subsequent PRs where I switch the behavior.
