### PR TITLE
have migration helpers use adapters for adapter-specific behavior

### DIFF
--- a/lib/ardb/adapter/base.rb
+++ b/lib/ardb/adapter/base.rb
@@ -2,7 +2,11 @@ module Ardb; end
 class Ardb::Adapter; end
 class Ardb::Adapter::Base
 
-  def initialize
+  def foreign_key_add_sql(*args);  raise NotImplementedError; end
+  def foreign_key_drop_sql(*args); raise NotImplementedError; end
+
+  def ==(other_adapter)
+    self.class == other_adapter.class
   end
 
 end

--- a/lib/ardb/adapter/mysql.rb
+++ b/lib/ardb/adapter/mysql.rb
@@ -5,6 +5,18 @@ class Ardb::Adapter
 
   class Mysql < Base
 
+    def foreign_key_add_sql(data={})
+      "ALTER TABLE :from_table"\
+      " ADD CONSTRAINT :name"\
+      " FOREIGN KEY (:from_column)"\
+      " REFERENCES :to_table (:to_column)"
+    end
+
+    def foreign_key_drop_sql(data={})
+      "ALTER TABLE :from_table"\
+      " DROP FOREIGN KEY :name"
+    end
+
   end
 
 end

--- a/lib/ardb/adapter/postgresql.rb
+++ b/lib/ardb/adapter/postgresql.rb
@@ -5,6 +5,18 @@ class Ardb::Adapter
 
   class Postgresql < Base
 
+    def foreign_key_add_sql(data={})
+      "ALTER TABLE :from_table"\
+      " ADD CONSTRAINT :name"\
+      " FOREIGN KEY (:from_column)"\
+      " REFERENCES :to_table (:to_column)"
+    end
+
+    def foreign_key_drop_sql(data={})
+      "ALTER TABLE :from_table"\
+      " DROP CONSTRAINT :name"
+    end
+
   end
 
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -16,7 +16,7 @@ require 'ardb'
 Ardb.configure do |c|
   c.root_path = TESTDB_PATH
 
-  c.db.adapter  'sqlite3'
-  c.db.database 'db/test.sqlite3'
+  c.db.adapter  'postgresql'
+  c.db.database 'ardbtest'
 
 end

--- a/test/unit/adapter/base_tests.rb
+++ b/test/unit/adapter/base_tests.rb
@@ -10,8 +10,11 @@ class Ardb::Adapter::Base
     end
     subject { @adapter }
 
-    should "test stuff" do
-      skip 'TODO tests'
+    should have_imeths :foreign_key_add_sql, :foreign_key_drop_sql
+
+    should "not implement the foreign key sql meths" do
+      assert_raises(NotImplementedError) { subject.foreign_key_add_sql }
+      assert_raises(NotImplementedError) { subject.foreign_key_drop_sql }
     end
 
   end

--- a/test/unit/adapter/mysql_tests.rb
+++ b/test/unit/adapter/mysql_tests.rb
@@ -10,8 +10,18 @@ class Ardb::Adapter::Mysql
     end
     subject { @adapter }
 
-    should "test stuff" do
-      skip 'TODO tests'
+    should "know its foreign key add sql" do
+      exp_add_sql = "ALTER TABLE :from_table"\
+                    " ADD CONSTRAINT :name"\
+                    " FOREIGN KEY (:from_column)"\
+                    " REFERENCES :to_table (:to_column)"
+      assert_equal exp_add_sql, subject.foreign_key_add_sql
+    end
+
+    should "know its foreign key drop sql" do
+      exp_drop_sql = "ALTER TABLE :from_table"\
+                     " DROP FOREIGN KEY :name"
+      assert_equal exp_drop_sql, subject.foreign_key_drop_sql
     end
 
   end

--- a/test/unit/adapter/postgresql_tests.rb
+++ b/test/unit/adapter/postgresql_tests.rb
@@ -10,8 +10,18 @@ class Ardb::Adapter::Postgresql
     end
     subject { @adapter }
 
-    should "test stuff" do
-      skip 'TODO tests'
+    should "know its foreign key add sql" do
+      exp_add_sql = "ALTER TABLE :from_table"\
+                    " ADD CONSTRAINT :name"\
+                    " FOREIGN KEY (:from_column)"\
+                    " REFERENCES :to_table (:to_column)"
+      assert_equal exp_add_sql, subject.foreign_key_add_sql
+    end
+
+    should "know its foreign key drop sql" do
+      exp_drop_sql = "ALTER TABLE :from_table"\
+                     " DROP CONSTRAINT :name"
+      assert_equal exp_drop_sql, subject.foreign_key_drop_sql
     end
 
   end

--- a/test/unit/adapter/sqlite_tests.rb
+++ b/test/unit/adapter/sqlite_tests.rb
@@ -10,8 +10,9 @@ class Ardb::Adapter::Sqlite
     end
     subject { @adapter }
 
-    should "test stuff" do
-      skip 'TODO tests'
+    should "not implement the foreign key sql meths" do
+      assert_raises(NotImplementedError) { subject.foreign_key_add_sql }
+      assert_raises(NotImplementedError) { subject.foreign_key_drop_sql }
     end
 
   end

--- a/test/unit/ardb_tests.rb
+++ b/test/unit/ardb_tests.rb
@@ -31,6 +31,8 @@ module Ardb
       end
 
       assert_not_nil Adapter.current
+      exp_adapter = Adapter.send(subject.config.db.adapter)
+      assert_equal exp_adapter, Adapter.current
       assert_same Adapter.current, subject.adapter
     end
 

--- a/test/unit/migration_helpers_tests.rb
+++ b/test/unit/migration_helpers_tests.rb
@@ -42,33 +42,20 @@ module Ardb::MigrationHelpers
     end
 
     should "use Ardb's config db adapter" do
-      assert_equal Ardb.config.db.adapter, subject.adapter
+      exp_adapter = Ardb::Adapter.send(Ardb.config.db.adapter)
+      assert_equal exp_adapter, subject.adapter
     end
 
-    should "support the `postgresql` adapter" do
+    should "generate appropriate foreign key sql" do
       exp_add_sql = "ALTER TABLE fromtbl"\
                     " ADD CONSTRAINT fk_fromtbl_fromcol"\
                     " FOREIGN KEY (fromcol)"\
                     " REFERENCES totbl (id)"
-      assert_equal exp_add_sql, subject.send('postgresql_add_sql')
+      assert_equal exp_add_sql, subject.add_sql
 
       exp_drop_sql = "ALTER TABLE fromtbl"\
                      " DROP CONSTRAINT fk_fromtbl_fromcol"
-      assert_equal exp_drop_sql, subject.send('postgresql_drop_sql')
-    end
-
-    should "support the `mysql` and `mysql2` adapters" do
-      exp_add_sql = "ALTER TABLE fromtbl"\
-                    " ADD CONSTRAINT fk_fromtbl_fromcol"\
-                    " FOREIGN KEY (fromcol)"\
-                    " REFERENCES totbl (id)"
-      assert_equal exp_add_sql, subject.send('mysql_add_sql')
-      assert_equal exp_add_sql, subject.send('mysql2_add_sql')
-
-      exp_drop_sql = "ALTER TABLE fromtbl"\
-                     " DROP FOREIGN KEY fk_fromtbl_fromcol"
-      assert_equal exp_drop_sql, subject.send('mysql_drop_sql')
-      assert_equal exp_drop_sql, subject.send('mysql2_drop_sql')
+      assert_equal exp_drop_sql, subject.drop_sql
     end
 
   end


### PR DESCRIPTION
This uses the new adapter modeling to implement the adapter-specific migration helper behavior.

@jcredding ready for review.
