### PR TITLE
have the create and drop subcommands use the adapters

### DIFF
--- a/lib/ardb/adapter/base.rb
+++ b/lib/ardb/adapter/base.rb
@@ -2,8 +2,18 @@ module Ardb; end
 class Ardb::Adapter; end
 class Ardb::Adapter::Base
 
+  attr_reader :config_settings, :database
+
+  def initialize
+    @config_settings = Ardb.config.db.to_hash
+    @database = Ardb.config.db.database
+  end
+
   def foreign_key_add_sql(*args);  raise NotImplementedError; end
   def foreign_key_drop_sql(*args); raise NotImplementedError; end
+
+  def create_db(*args); raise NotImplementedError; end
+  def drop_db(*args);   raise NotImplementedError; end
 
   def ==(other_adapter)
     self.class == other_adapter.class

--- a/lib/ardb/adapter/mysql.rb
+++ b/lib/ardb/adapter/mysql.rb
@@ -5,14 +5,14 @@ class Ardb::Adapter
 
   class Mysql < Base
 
-    def foreign_key_add_sql(data={})
+    def foreign_key_add_sql
       "ALTER TABLE :from_table"\
       " ADD CONSTRAINT :name"\
       " FOREIGN KEY (:from_column)"\
       " REFERENCES :to_table (:to_column)"
     end
 
-    def foreign_key_drop_sql(data={})
+    def foreign_key_drop_sql
       "ALTER TABLE :from_table"\
       " DROP FOREIGN KEY :name"
     end

--- a/lib/ardb/adapter/postgresql.rb
+++ b/lib/ardb/adapter/postgresql.rb
@@ -5,14 +5,32 @@ class Ardb::Adapter
 
   class Postgresql < Base
 
-    def foreign_key_add_sql(data={})
+    def public_schema_settings
+      self.config_settings.merge({
+        :database           => 'postgres',
+        :schema_search_path => 'public'
+      })
+    end
+
+    def create_db
+      ActiveRecord::Base.establish_connection(self.public_schema_settings)
+      ActiveRecord::Base.connection.create_database(self.database, self.config_settings)
+      ActiveRecord::Base.establish_connection(self.config_settings)
+    end
+
+    def drop_db
+      ActiveRecord::Base.establish_connection(self.public_schema_settings)
+      ActiveRecord::Base.connection.drop_database(self.database)
+    end
+
+    def foreign_key_add_sql
       "ALTER TABLE :from_table"\
       " ADD CONSTRAINT :name"\
       " FOREIGN KEY (:from_column)"\
       " REFERENCES :to_table (:to_column)"
     end
 
-    def foreign_key_drop_sql(data={})
+    def foreign_key_drop_sql
       "ALTER TABLE :from_table"\
       " DROP CONSTRAINT :name"
     end

--- a/lib/ardb/adapter/sqlite.rb
+++ b/lib/ardb/adapter/sqlite.rb
@@ -1,9 +1,35 @@
+require 'pathname'
+require 'fileutils'
 require 'ardb'
 require 'ardb/adapter/base'
 
 class Ardb::Adapter
 
   class Sqlite < Base
+
+    def db_file_path
+      if (path = Pathname.new(self.database)).absolute?
+        path.to_s
+      else
+        Ardb.config.root_path.join(path).to_s
+      end
+    end
+
+    def validate!
+      if File.exist?(self.db_file_path)
+        raise Ardb::Runner::CmdError, "#{self.database} already exists"
+      end
+    end
+
+    def create_db
+      validate!
+      FileUtils.mkdir_p File.dirname(self.db_file_path)
+      ActiveRecord::Base.establish_connection(self.config_settings)
+    end
+
+    def drop_db
+      FileUtils.rm(self.db_file_path) if File.exist?(self.db_file_path)
+    end
 
   end
 

--- a/lib/ardb/runner/create_command.rb
+++ b/lib/ardb/runner/create_command.rb
@@ -3,65 +3,19 @@ require 'ardb/runner'
 
 class Ardb::Runner::CreateCommand
 
+  def initialize
+    @adapter = Ardb::Adapter.send(Ardb.config.db.adapter)
+  end
+
   def run
     begin
-      self.send("#{Ardb.config.db.adapter}_cmd")
+      @adapter.create_db
       $stdout.puts "created #{Ardb.config.db.adapter} db `#{Ardb.config.db.database}`"
     rescue Ardb::Runner::CmdError => e
       raise e
     rescue Exception => e
       $stderr.puts e, *(e.backtrace)
       $stderr.puts "error creating #{Ardb.config.db.database.inspect} database"
-    end
-  end
-
-  def postgresql_cmd
-    PostgresqlCommand.new.run
-  end
-
-  def sqlite3_cmd
-    SqliteCommand.new.run
-  end
-
-  class PostgresqlCommand
-    attr_reader :config_settings, :database
-
-    def initialize
-      @config_settings = Ardb.config.db.to_hash
-      @database = Ardb.config.db.database
-    end
-
-    def run
-      ActiveRecord::Base.establish_connection(@config_settings.merge({
-        :database           => 'postgres',
-        :schema_search_path => 'public'
-      }))
-      ActiveRecord::Base.connection.create_database(@database, @config_settings)
-      ActiveRecord::Base.establish_connection(@config_settings)
-    end
-  end
-
-  class SqliteCommand
-    attr_reader :config_settings, :database, :db_path
-
-    def initialize
-      @config_settings = Ardb.config.db.to_hash
-      @database = Ardb.config.db.database
-      @db_path = if (path = Pathname.new(@database)).absolute?
-        path.to_s
-      else
-        Ardb.config.root_path.join(path).to_s
-      end
-    end
-
-    def validate!
-      raise Ardb::Runner::CmdError, "#{@database} already exists" if File.exist?(@db_path)
-    end
-
-    def run
-      validate!
-      FileUtils.mkdir_p File.dirname(@db_path)
-      ActiveRecord::Base.establish_connection(@config_settings)
     end
   end
 

--- a/lib/ardb/runner/drop_command.rb
+++ b/lib/ardb/runner/drop_command.rb
@@ -3,58 +3,19 @@ require 'ardb/runner'
 
 class Ardb::Runner::DropCommand
 
+  def initialize
+    @adapter = Ardb::Adapter.send(Ardb.config.db.adapter)
+  end
+
   def run
     begin
-      self.send("#{Ardb.config.db.adapter}_cmd")
+      @adapter.drop_db
       $stdout.puts "dropped #{Ardb.config.db.adapter} db `#{Ardb.config.db.database}`"
     rescue Ardb::Runner::CmdError => e
       raise e
     rescue Exception => e
       $stderr.puts e, *(e.backtrace)
       $stderr.puts "error dropping #{Ardb.config.db.database.inspect} database"
-    end
-  end
-
-  def postgresql_cmd
-    PostgresqlCommand.new.run
-  end
-
-  def sqlite3_cmd
-    SqliteCommand.new.run
-  end
-
-  class PostgresqlCommand
-    attr_reader :config_settings, :database
-
-    def initialize
-      @config_settings = Ardb.config.db.to_hash
-      @database = Ardb.config.db.database
-    end
-
-    def run
-      ActiveRecord::Base.establish_connection(@config_settings.merge({
-        :database           => 'postgres',
-        :schema_search_path => 'public'
-      }))
-      ActiveRecord::Base.connection.drop_database(@database)
-    end
-  end
-
-  class SqliteCommand
-    attr_reader :config_settings, :database, :db_path
-
-    def initialize
-      @config_settings = Ardb.config.db.to_hash
-      @database = Ardb.config.db.database
-      @db_path = if (path = Pathname.new(@database)).absolute?
-        path.to_s
-      else
-        Ardb.config.root_path.join(path).to_s
-      end
-    end
-
-    def run
-      FileUtils.rm(@db_path) if File.exist?(@db_path)
     end
   end
 

--- a/test/unit/adapter/base_tests.rb
+++ b/test/unit/adapter/base_tests.rb
@@ -10,11 +10,26 @@ class Ardb::Adapter::Base
     end
     subject { @adapter }
 
+    should have_reader :config_settings, :database
     should have_imeths :foreign_key_add_sql, :foreign_key_drop_sql
+    should have_imeths :create_db, :drop_db
+
+    should "use the config's db settings " do
+      assert_equal Ardb.config.db.to_hash, subject.config_settings
+    end
+
+    should "use the config's database" do
+      assert_equal Ardb.config.db.database, subject.database
+    end
 
     should "not implement the foreign key sql meths" do
       assert_raises(NotImplementedError) { subject.foreign_key_add_sql }
       assert_raises(NotImplementedError) { subject.foreign_key_drop_sql }
+    end
+
+    should "not implement the create and drop db methods" do
+      assert_raises(NotImplementedError) { subject.create_db }
+      assert_raises(NotImplementedError) { subject.drop_db }
     end
 
   end

--- a/test/unit/adapter/mysql_tests.rb
+++ b/test/unit/adapter/mysql_tests.rb
@@ -24,6 +24,12 @@ class Ardb::Adapter::Mysql
       assert_equal exp_drop_sql, subject.foreign_key_drop_sql
     end
 
+    # not currently implemented, see: https://github.com/redding/ardb/issues/13
+    should "not implement the create and drop db methods" do
+      assert_raises(NotImplementedError) { subject.create_db }
+      assert_raises(NotImplementedError) { subject.drop_db }
+    end
+
   end
 
 end

--- a/test/unit/adapter/postgresql_tests.rb
+++ b/test/unit/adapter/postgresql_tests.rb
@@ -10,6 +10,16 @@ class Ardb::Adapter::Postgresql
     end
     subject { @adapter }
 
+    should have_instance_method :public_schema_settings
+
+    should "know it's public schema connection settings" do
+      exp_settings = subject.config_settings.merge({
+        :database => 'postgres',
+        :schema_search_path => 'public'
+      })
+      assert_equal exp_settings, subject.public_schema_settings
+    end
+
     should "know its foreign key add sql" do
       exp_add_sql = "ALTER TABLE :from_table"\
                     " ADD CONSTRAINT :name"\

--- a/test/unit/adapter/sqlite_tests.rb
+++ b/test/unit/adapter/sqlite_tests.rb
@@ -10,6 +10,20 @@ class Ardb::Adapter::Sqlite
     end
     subject { @adapter }
 
+    should have_imeths :db_file_path, :validate!
+
+    should "complain if the db file already exists" do
+      FileUtils.mkdir_p(File.dirname(subject.db_file_path))
+      FileUtils.touch(subject.db_file_path)
+      assert_raises(Ardb::Runner::CmdError) { subject.validate! }
+      FileUtils.rm(subject.db_file_path)
+    end
+
+    should "know its db_file_path" do
+      exp_path = Ardb.config.root_path.join(Ardb.config.db.database).to_s
+      assert_equal exp_path, subject.db_file_path
+    end
+
     should "not implement the foreign key sql meths" do
       assert_raises(NotImplementedError) { subject.foreign_key_add_sql }
       assert_raises(NotImplementedError) { subject.foreign_key_drop_sql }

--- a/test/unit/runner/create_command_tests.rb
+++ b/test/unit/runner/create_command_tests.rb
@@ -11,56 +11,7 @@ class Ardb::Runner::CreateCommand
     end
     subject{ @cmd }
 
-    should have_instance_methods :run, :postgresql_cmd, :sqlite3_cmd
-
-  end
-
-  class PostgresqlTests < BaseTests
-    desc "Ardb::Runner::CreateCommand::PostgresqlCommand"
-    setup do
-      @cmd = Ardb::Runner::CreateCommand::PostgresqlCommand.new
-    end
-
-    should have_readers :config_settings, :database
-
-    should "use the config's db settings " do
-      assert_equal Ardb.config.db.to_hash, subject.config_settings
-    end
-
-    should "use the config's database" do
-      assert_equal Ardb.config.db.database, subject.database
-    end
-
-  end
-
-  class SqliteTests < BaseTests
-    desc "Ardb::Runner::CreateCommand::SqliteCommand"
-    setup do
-      @cmd = Ardb::Runner::CreateCommand::SqliteCommand.new
-    end
-
-    should have_readers :config_settings, :database, :db_path
-    should have_instance_method :validate!
-
-    should "use the config's db settings " do
-      assert_equal Ardb.config.db.to_hash, subject.config_settings
-    end
-
-    should "use the config's database" do
-      assert_equal Ardb.config.db.database, subject.database
-    end
-
-    should "know the full path to the db file" do
-      exp_path = Ardb.config.root_path.join(Ardb.config.db.database).to_s
-      assert_equal exp_path, subject.db_path
-    end
-
-    should "complain if the db file already exists" do
-      FileUtils.mkdir_p(File.dirname(subject.db_path))
-      FileUtils.touch(subject.db_path)
-      assert_raises(Ardb::Runner::CmdError) { subject.validate! }
-      FileUtils.rm(subject.db_path)
-    end
+    should have_instance_methods :run
 
   end
 

--- a/test/unit/runner/drop_command_tests.rb
+++ b/test/unit/runner/drop_command_tests.rb
@@ -10,48 +10,7 @@ class Ardb::Runner::DropCommand
     end
     subject{ @cmd }
 
-    should have_instance_methods :run, :postgresql_cmd
-
-  end
-
-  class PostgresqlTests < BaseTests
-    desc "Ardb::Runner::DropCommand::PostgresqlCommand"
-    setup do
-      @cmd = Ardb::Runner::DropCommand::PostgresqlCommand.new
-    end
-
-    should have_readers :config_settings, :database
-
-    should "use the config's db settings " do
-      assert_equal Ardb.config.db.to_hash, subject.config_settings
-    end
-
-    should "use the config's database" do
-      assert_equal Ardb.config.db.database, subject.database
-    end
-
-  end
-
-  class SqliteTests < BaseTests
-    desc "Ardb::Runner::DropCommand::SqliteCommand"
-    setup do
-      @cmd = Ardb::Runner::DropCommand::SqliteCommand.new
-    end
-
-    should have_readers :config_settings, :database, :db_path
-
-    should "use the config's db settings " do
-      assert_equal Ardb.config.db.to_hash, subject.config_settings
-    end
-
-    should "use the config's database" do
-      assert_equal Ardb.config.db.database, subject.database
-    end
-
-    should "know the full path to the db file" do
-      exp_path = Ardb.config.root_path.join(Ardb.config.db.database).to_s
-      assert_equal exp_path, subject.db_path
-    end
+    should have_instance_methods :run
 
   end
 

--- a/tmp/pgtest/Gemfile.lock
+++ b/tmp/pgtest/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     ardb (0.0.1)
       activerecord (~> 3.2)
+      activesupport (~> 3.2)
       ns-options (~> 1.1)
 
 GEM

--- a/tmp/sqlitetest/Gemfile.lock
+++ b/tmp/sqlitetest/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     ardb (0.0.1)
       activerecord (~> 3.2)
+      activesupport (~> 3.2)
       ns-options (~> 1.1)
 
 GEM


### PR DESCRIPTION
This moves the adapter specific behavior related to these cmds into
the adapter models.

The goal is to remove the duplication between the cmd implementations
and to centralize adapter-specific behavior.

@jcredding ready for review.
