### PR TITLE
handle logger configuration

### DIFF
--- a/lib/ardb.rb
+++ b/lib/ardb.rb
@@ -24,6 +24,7 @@ module Ardb
     Adapter.init
 
     # setup AR
+    ActiveRecord::Base.logger = self.config.logger
     ActiveRecord::Base.establish_connection(self.config.db.to_hash)
   end
 
@@ -40,6 +41,7 @@ module Ardb
     end
 
     option :root_path,       Pathname, :required => true
+    option :logger,                    :required => true
     option :migrations_path, String,   :default => proc{ default_migrations_path }
     option :schema_path,     String,   :default => proc{ default_schema_path }
 

--- a/lib/ardb/cli.rb
+++ b/lib/ardb/cli.rb
@@ -32,6 +32,8 @@ module Ardb
       rescue Ardb::NotConfiguredError, Ardb::Runner::CmdError => err
         $stderr.puts "#{err.message}"
         exit(1)
+      rescue Ardb::Runner::CmdFail => err
+        exit(1)
       rescue CLIRB::Error => exception
         $stderr.puts "#{exception.message}\n\n"
         $stderr.puts help

--- a/lib/ardb/runner.rb
+++ b/lib/ardb/runner.rb
@@ -4,6 +4,7 @@ module Ardb; end
 class Ardb::Runner
   UnknownCmdError = Class.new(ArgumentError)
   CmdError = Class.new(RuntimeError)
+  CmdFail = Class.new(RuntimeError)
 
   attr_reader :cmd_name, :cmd_args, :opts, :root_path
 
@@ -43,6 +44,7 @@ class Ardb::Runner
     DbConfigFile.new.require_if_exists
     Ardb.validate!
     Ardb::Adapter.init
+    ActiveRecord::Base.logger = Ardb.config.logger
   end
 
   class DbConfigFile

--- a/lib/ardb/runner/create_command.rb
+++ b/lib/ardb/runner/create_command.rb
@@ -14,8 +14,7 @@ class Ardb::Runner::CreateCommand
     rescue Ardb::Runner::CmdError => e
       raise e
     rescue Exception => e
-      $stderr.puts e, *(e.backtrace)
-      $stderr.puts "error creating #{Ardb.config.db.database.inspect} database"
+      raise Ardb::Runner::CmdFail
     end
   end
 

--- a/lib/ardb/runner/drop_command.rb
+++ b/lib/ardb/runner/drop_command.rb
@@ -14,8 +14,7 @@ class Ardb::Runner::DropCommand
     rescue Ardb::Runner::CmdError => e
       raise e
     rescue Exception => e
-      $stderr.puts e, *(e.backtrace)
-      $stderr.puts "error dropping #{Ardb.config.db.database.inspect} database"
+      raise Ardb::Runner::CmdFail
     end
   end
 

--- a/lib/ardb/runner/migrate_command.rb
+++ b/lib/ardb/runner/migrate_command.rb
@@ -21,8 +21,7 @@ class Ardb::Runner::MigrateCommand
     rescue Ardb::Runner::CmdError => e
       raise e
     rescue Exception => e
-      $stderr.puts e, *(e.backtrace)
-      $stderr.puts "error migrating #{Ardb.config.db.database.inspect} database"
+      raise Ardb::Runner::CmdFail
     end
   end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -12,9 +12,11 @@ require 'fileutils'
 TESTDB_PATH = File.join(ROOT_PATH, 'tmp', 'testdb')
 FileUtils.mkdir_p TESTDB_PATH
 
+require 'logger'
 require 'ardb'
 Ardb.configure do |c|
   c.root_path = TESTDB_PATH
+  c.logger = Logger.new($stdout)
 
   c.db.adapter  'postgresql'
   c.db.database 'ardbtest'

--- a/test/unit/ardb_tests.rb
+++ b/test/unit/ardb_tests.rb
@@ -6,8 +6,12 @@ module Ardb
   class BaseTests < Assert::Context
     desc "Ardb"
     subject{ Ardb }
+    setup do
+      @orig_ar_logger = ActiveRecord::Base.logger
+    end
     teardown do
       Adapter.reset
+      ActiveRecord::Base.logger = @orig_ar_logger
     end
 
     should have_imeths :config, :configure, :adapter, :validate!, :init

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -11,6 +11,7 @@ class Ardb::Config
 
     should have_namespace :db
     should have_option  :root_path, Pathname, :required => true
+    should have_option  :logger, :required => true
     should have_options :migrations_path, :schema_path
 
     should "should use `db/migrations` as the default migrations path" do

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -1,5 +1,6 @@
 require 'assert'
 require 'pathname'
+require 'active_record'
 require 'ardb/runner'
 
 class Ardb::Runner
@@ -52,6 +53,13 @@ class Ardb::Runner
       assert_nil Ardb.adapter
       subject.run
       assert_not_nil Ardb.adapter
+    end
+
+    should "set the AR logger" do
+      default_ar_logger = ActiveRecord::Base.logger
+      subject.run
+      assert_equal Ardb.config.logger, ActiveRecord::Base.logger
+      ActiveRecord::Base.logger = default_ar_logger
     end
 
     should "complain about unknown cmds" do


### PR DESCRIPTION
This adds a `logger` config and handles configuring AR's logger
for you.  The logger is set on `init` and on the Runner's `setup_run`.

This also tweaks the `create`, `drop`, and `migrate subcommands to
rely on AR's logging and the configured logger.

@jcredding ready for review.
