### PR TITLE
have the migration generator include the migration helpers

### DIFF
--- a/lib/ardb/migration_helpers.rb
+++ b/lib/ardb/migration_helpers.rb
@@ -25,11 +25,11 @@ module Ardb::MigrationHelpers
 
     def initialize(from_table, from_column, to_table, options=nil)
       options ||= {}
-      @from_table  = from_table
-      @from_column = from_column
-      @to_table    = to_table
-      @to_column   = (options[:to_column] || 'id')
-      @name        = (options[:name] || "fk_#{@from_table}_#{@from_column}")
+      @from_table  = from_table.to_s
+      @from_column = from_column.to_s
+      @to_table    = to_table.to_s
+      @to_column   = (options[:to_column] || 'id').to_s
+      @name        = (options[:name] || "fk_#{@from_table}_#{@from_column}").to_s
       @adapter     = Ardb::Adapter.send(Ardb.config.db.adapter)
     end
 

--- a/lib/ardb/runner/generate_command.rb
+++ b/lib/ardb/runner/generate_command.rb
@@ -24,6 +24,7 @@ class Ardb::Runner::GenerateCommand
     rescue Exception => e
       $stderr.puts e, *(e.backtrace)
       $stderr.puts "error generating #{@item}."
+      raise Ardb::Runner::CmdFail
     end
   end
 
@@ -44,9 +45,11 @@ class Ardb::Runner::GenerateCommand
       @file_name  = begin
         "#{Time.now.strftime("%Y%m%d%H%M%S")}_#{@identifier.underscore}"
       end
-      @template = "class #{@class_name} < ActiveRecord::Migration\n"\
+      @template = "require 'ardb/migration_helpers'\n\n"\
+                  "class #{@class_name} < ActiveRecord::Migration\n"\
+                  "  include Ardb::MigrationHelpers\n\n"\
                   "  def change\n"\
-                  "  end\n"\
+                  "  end\n\n"\
                   "end\n"
     end
 

--- a/lib/ardb/runner/migrate_command.rb
+++ b/lib/ardb/runner/migrate_command.rb
@@ -21,6 +21,8 @@ class Ardb::Runner::MigrateCommand
     rescue Ardb::Runner::CmdError => e
       raise e
     rescue Exception => e
+      $stderr.puts e, *(e.backtrace)
+      $stderr.puts "error migrating #{Ardb.config.db.database.inspect} database"
       raise Ardb::Runner::CmdFail
     end
   end

--- a/test/unit/runner/generate_command_tests.rb
+++ b/test/unit/runner/generate_command_tests.rb
@@ -35,7 +35,9 @@ class Ardb::Runner::GenerateCommand
     end
 
     should "know its template" do
+      assert_includes "require 'ardb/migration_helpers'", subject.template
       assert_includes "class #{subject.class_name} < ActiveRecord::Migration", subject.template
+      assert_includes "include Ardb::MigrationHelpers", subject.template
       assert_includes "def change", subject.template
     end
 


### PR DESCRIPTION
This is so you don't have to remember to include them, they are just
there by default.

Closes #25.

@jcredding ready for review.
