### PR TITLE
adapter-specific `drop_tables` helper

### DIFF
--- a/lib/ardb/adapter/base.rb
+++ b/lib/ardb/adapter/base.rb
@@ -15,6 +15,8 @@ class Ardb::Adapter::Base
   def create_db(*args); raise NotImplementedError; end
   def drop_db(*args);   raise NotImplementedError; end
 
+  def drop_tables(*args); raise NotImplementedError; end
+
   def ==(other_adapter)
     self.class == other_adapter.class
   end

--- a/lib/ardb/adapter/postgresql.rb
+++ b/lib/ardb/adapter/postgresql.rb
@@ -23,6 +23,15 @@ class Ardb::Adapter
       ActiveRecord::Base.connection.drop_database(self.database)
     end
 
+    def drop_tables
+      ActiveRecord::Base.connection.tap do |conn|
+        tables = conn.execute "SELECT table_name"\
+                              " FROM information_schema.tables"\
+                              " WHERE table_schema = 'public';"
+        tables.each{ |row| conn.execute "DROP TABLE #{row['table_name']} CASCADE" }
+      end
+    end
+
     def foreign_key_add_sql
       "ALTER TABLE :from_table"\
       " ADD CONSTRAINT :name"\

--- a/lib/ardb/test_helpers.rb
+++ b/lib/ardb/test_helpers.rb
@@ -9,12 +9,7 @@ module Ardb::TestHelpers
   module_function
 
   def drop_tables
-    ActiveRecord::Base.connection.tap do |conn|
-      tables = conn.execute "SELECT table_name"\
-                            " FROM information_schema.tables"\
-                            " WHERE table_schema = 'public';"
-      tables.each{ |row| conn.execute "DROP TABLE #{row['table_name']} CASCADE" }
-    end
+    Ardb.adapter.drop_tables
   end
 
   def load_schema

--- a/test/unit/adapter/base_tests.rb
+++ b/test/unit/adapter/base_tests.rb
@@ -32,6 +32,10 @@ class Ardb::Adapter::Base
       assert_raises(NotImplementedError) { subject.drop_db }
     end
 
+    should "not implement the drop table methods" do
+      assert_raises(NotImplementedError) { subject.drop_tables }
+    end
+
   end
 
 end

--- a/test/unit/adapter/mysql_tests.rb
+++ b/test/unit/adapter/mysql_tests.rb
@@ -30,6 +30,11 @@ class Ardb::Adapter::Mysql
       assert_raises(NotImplementedError) { subject.drop_db }
     end
 
+    # not currently implemented, see: https://github.com/redding/ardb/issues/28
+    should "not implement the drop tables method" do
+      assert_raises(NotImplementedError) { subject.drop_tables }
+    end
+
   end
 
 end

--- a/test/unit/adapter/sqlite_tests.rb
+++ b/test/unit/adapter/sqlite_tests.rb
@@ -29,6 +29,11 @@ class Ardb::Adapter::Sqlite
       assert_raises(NotImplementedError) { subject.foreign_key_drop_sql }
     end
 
+    # not currently implemented, see: https://github.com/redding/ardb/issues/29
+    should "not implement the drop tables method" do
+      assert_raises(NotImplementedError) { subject.drop_tables }
+    end
+
   end
 
 end


### PR DESCRIPTION
This moves the adapter-specific behavior in `drop_tables` into the
adapters.  Right now it is only supported in the Postgres adapter.

This picks up on work in #27.

@jcredding ready for review.
