### PR TITLE
allow dropping pg databases even if there are active connections

### DIFF
--- a/test/unit/adapter/postgresql_tests.rb
+++ b/test/unit/adapter/postgresql_tests.rb
@@ -14,8 +14,8 @@ class Ardb::Adapter::Postgresql
 
     should "know it's public schema connection settings" do
       exp_settings = subject.config_settings.merge({
-        :database => 'postgres',
-        :schema_search_path => 'public'
+        'database' => 'postgres',
+        'schema_search_path' => 'public'
       })
       assert_equal exp_settings, subject.public_schema_settings
     end


### PR DESCRIPTION
You gotta get tricky with postgres to get around there restriction
on dropping databases that have active connections.

See:
- http://stackoverflow.com/a/15729440
- http://www.postgresql.org/docs/9.2/static/functions-admin.html#FUNCTIONS-ADMIN-SIGNAL-TABLE

@jcredding rolling this - heads up.
