### PR TITLE
updating the db file handling to follow the Sanford pattern

### DIFF
--- a/lib/ardb.rb
+++ b/lib/ardb.rb
@@ -6,6 +6,8 @@ require 'ns-options'
 require 'ardb/version'
 require 'ardb/root_path'
 
+ENV['ARDB_DB_FILE'] ||= 'config/db'
+
 module Ardb
   NotConfiguredError = Class.new(RuntimeError)
 
@@ -21,6 +23,7 @@ module Ardb
   end
 
   def self.init(establish_connection=true)
+    require self.config.db_file
     validate!
     Adapter.init
 
@@ -44,6 +47,7 @@ module Ardb
       option :password, String,  :required => false
     end
 
+    option :db_file,         Pathname, :default => ENV['ARDB_DB_FILE']
     option :root_path,       Pathname, :required => true
     option :logger,                    :required => true
     option :migrations_path, RootPath, :default => proc{ "db/migrations" }

--- a/lib/ardb/runner.rb
+++ b/lib/ardb/runner.rb
@@ -1,7 +1,5 @@
 require 'ardb'
 
-ENV['ARDB_CONFIG_FILE'] ||= 'config/db'
-
 module Ardb; end
 class Ardb::Runner
   UnknownCmdError = Class.new(ArgumentError)
@@ -17,7 +15,8 @@ class Ardb::Runner
   end
 
   def run
-    setup_run
+    Ardb.init(false) # don't establish a connection
+
     case @cmd_name
     when 'migrate'
       require 'ardb/runner/migrate_command'
@@ -39,13 +38,6 @@ class Ardb::Runner
     else
       raise UnknownCmdError, "unknown command `#{@cmd_name}`"
     end
-  end
-
-  private
-
-  def setup_run
-    require ENV['ARDB_CONFIG_FILE']
-    Ardb.init(false) # don't establish a connection
   end
 
   class NullCommand

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -7,5 +7,6 @@ $LOAD_PATH.unshift(File.expand_path("../..", __FILE__))
 # require pry for debugging (`binding.pry`)
 require 'pry'
 
-ENV['ARDB_CONFIG_FILE'] = 'tmp/testdb/config/db'
-require ENV['ARDB_CONFIG_FILE']
+ENV['ARDB_DB_FILE'] = 'tmp/testdb/config/db'
+require 'ardb'
+Ardb.init(false)

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -10,6 +10,7 @@ class Ardb::Config
     subject{ Ardb::Config }
 
     should have_namespace :db
+    should have_option  :db_file,   Pathname, :default => ENV['ARDB_DB_FILE']
     should have_option  :root_path, Pathname, :required => true
     should have_option  :logger, :required => true
     should have_options :migrations_path, :schema_path

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -25,6 +25,7 @@ class Ardb::Runner
   class RunTests < BaseTests
     desc "when running a command"
     setup do
+      Ardb::Adapter.reset
       @runner = Ardb::Runner.new(['null', 1, 2], {})
     end
     teardown do

--- a/tmp/sqlitetest/Gemfile.lock
+++ b/tmp/sqlitetest/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: /Users/kelly/projects/redding/ardb
   specs:
-    ardb (0.4.1)
+    ardb (0.5.0)
       activerecord (~> 3.2)
       activesupport (~> 3.2)
       ns-options (~> 1.1)


### PR DESCRIPTION
Define a config for the db file, default it with an ENV var.  Then
require in the db file on `init`.

This updates Ardb to this pattern - the goal is to be as similar
to Sanford as possible.  The reason for this is they are both
gems, with CLIs, that need some configs in an expected file, and then
do stuff.

@jcredding ready for review.
