### PR TITLE
Add ActiveRecord spy for testing mixins and configuration

### DIFF
--- a/lib/ardb/record_spy.rb
+++ b/lib/ardb/record_spy.rb
@@ -1,0 +1,73 @@
+module Ardb
+
+  module RecordSpy
+
+    def self.new(&block)
+      block ||= proc{ }
+      record_spy = Class.new{ include Ardb::RecordSpy }
+      record_spy.class_eval(&block)
+      record_spy
+    end
+
+    def self.included(klass)
+      klass.class_eval do
+        extend ClassMethods
+        include InstanceMethods
+      end
+    end
+
+    module ClassMethods
+
+      attr_reader :validations, :callbacks
+
+      [ :validates_presence_of, :validates_uniqueness_of,
+        :validates_inclusion_of
+      ].each do |method_name|
+        type = method_name.to_s.match(/\Avalidates_(.+)_of\Z/)[1]
+
+        define_method(method_name) do |*args|
+          @validations ||= []
+          @validations << Validation.new(type, *args)
+        end
+
+      end
+
+      [ :before_validation, :after_save ].each do |method_name|
+
+        define_method(method_name) do |*args, &block|
+          @callbacks ||= []
+          @callbacks << Callback.new(method_name, *args, &block)
+        end
+
+      end
+
+    end
+
+    module InstanceMethods
+
+    end
+
+    class Validation
+      attr_reader :type, :columns, :options
+
+      def initialize(type, *args)
+        @type    = type.to_sym
+        @options = args.last.kind_of?(::Hash) ? args.pop : {}
+        @columns = args
+      end
+    end
+
+    class Callback
+      attr_reader :type, :args, :options, :block
+
+      def initialize(type, *args, &block)
+        @type  = type.to_sym
+        @options = args.last.kind_of?(::Hash) ? args.pop : {}
+        @args  = args
+        @block = block
+      end
+    end
+
+  end
+
+end

--- a/test/unit/record_spy_tests.rb
+++ b/test/unit/record_spy_tests.rb
@@ -1,0 +1,90 @@
+require 'assert'
+require 'ardb/record_spy'
+
+module Ardb::RecordSpy
+
+  class MyRecord
+    include Ardb::RecordSpy
+    attr_accessor :name
+  end
+
+  class BaseTests < Assert::Context
+    desc "Ardb::RecordSpy"
+    setup do
+      @instance = MyRecord.new
+    end
+    subject{ MyRecord }
+
+    should have_readers :validations, :callbacks
+    should have_imeths :validates_presence_of, :validates_uniqueness_of
+    should have_imeths :validates_inclusion_of, :before_validation, :after_save
+
+    should "included the record spy instance methods" do
+      assert_includes Ardb::RecordSpy::InstanceMethods, subject.included_modules
+    end
+
+    should "add a validation config with #validates_presence_of" do
+      subject.validates_presence_of :name, :email, :on => :create
+      validation = subject.validations.last
+      assert_equal :presence, validation.type
+      assert_includes :name, validation.columns
+      assert_includes :email, validation.columns
+      assert_equal :create, validation.options[:on]
+    end
+
+    should "add a validation config with #validates_uniqueness_of" do
+      subject.validates_uniqueness_of :name, :scope => :area_id
+      validation = subject.validations.last
+      assert_equal :uniqueness, validation.type
+      assert_includes :name, validation.columns
+      assert_equal :area_id, validation.options[:scope]
+    end
+
+    should "add a validation config with #validates_inclusion_of" do
+      subject.validates_inclusion_of :active, :in => [ true, false]
+      validation = subject.validations.last
+      assert_equal :inclusion, validation.type
+      assert_includes :active, validation.columns
+      assert_equal [ true, false], validation.options[:in]
+    end
+
+    should "add a callback config with #before_validation" do
+      subject.before_validation(:on => :create) do
+        self.name = 'test'
+      end
+      callback = subject.callbacks.last
+      assert_equal :before_validation, callback.type
+      assert_equal :create, callback.options[:on]
+      @instance.instance_eval(&callback.block)
+      assert_equal 'test', @instance.name
+    end
+
+    should "add a callback config with #after_save" do
+      subject.after_save :a_callback_method
+      callback = subject.callbacks.last
+      assert_equal :after_save, callback.type
+      assert_includes :a_callback_method, callback.args
+    end
+
+  end
+
+  class GeneratorTests < BaseTests
+    desc "to generate record spy classes"
+    setup do
+      @record_spy_class = Ardb::RecordSpy.new do
+        attr_accessor :name
+      end
+      @instance = @record_spy_class.new
+    end
+    subject{ @record_spy_class }
+
+    should "build a new record spy class and " \
+           "used the passed proc to further defined it" do
+      assert_includes Ardb::RecordSpy, subject.included_modules
+      assert @instance.respond_to? :name
+      assert @instance.respond_to? :name=
+    end
+
+  end
+
+end


### PR DESCRIPTION
This adds a `RecordSpy` for testing ActiveRecord mixins. This
is a useful tool for testing mixins that add ActiveRecord
validations, callbacks, etc. The goal is to be able to test these
mixins without actually providing an ActiveRecord model.

@kellyredding - I originally put an issue for this in MR, but I think it fits better in Ardb. I'd like to use when moving some of the record mixins in Pro to I-App.
