### PR TITLE
Expand the record spy's ability to capture ActiveRecord configuration

### DIFF
--- a/lib/ardb/record_spy.rb
+++ b/lib/ardb/record_spy.rb
@@ -41,7 +41,12 @@ module Ardb
 
       end
 
-      [ :before_validation, :after_save ].each do |method_name|
+      def validate(method_name = nil, &block)
+        @validations ||= []
+        @validations << Validation.new(:custom, method_name, &block)
+      end
+
+      [ :after_initialize, :before_validation, :after_save ].each do |method_name|
 
         define_method(method_name) do |*args, &block|
           @callbacks ||= []
@@ -78,12 +83,17 @@ module Ardb
     end
 
     class Validation
-      attr_reader :type, :columns, :options
+      attr_reader :type, :columns, :options, :method_name, :block
 
       def initialize(type, *args, &block)
         @type  = type.to_sym
-        @options = args.last.kind_of?(::Hash) ? args.pop : {}
-        @columns = args
+        @block = block
+        if type != :custom
+          @options = args.last.kind_of?(::Hash) ? args.pop : {}
+          @columns = args
+        else
+          @method_name = args.first
+        end
       end
     end
 

--- a/test/unit/record_spy_tests.rb
+++ b/test/unit/record_spy_tests.rb
@@ -18,7 +18,8 @@ module Ardb::RecordSpy
     should have_readers :associations, :callbacks, :validations
     should have_imeths :belongs_to, :has_many, :has_one
     should have_imeths :validates_presence_of, :validates_uniqueness_of
-    should have_imeths :validates_inclusion_of, :before_validation, :after_save
+    should have_imeths :validates_inclusion_of, :validate
+    should have_imeths :after_initialize, :before_validation, :after_save
 
     should "included the record spy instance methods" do
       assert_includes Ardb::RecordSpy::InstanceMethods, subject.included_modules
@@ -71,6 +72,26 @@ module Ardb::RecordSpy
       assert_equal :inclusion, validation.type
       assert_includes :active, validation.columns
       assert_equal [ true, false], validation.options[:in]
+    end
+
+    should "add a validation config with #validate" do
+      subject.validate :some_method
+      validation = subject.validations.last
+      assert_equal :custom,      validation.type
+      assert_equal :some_method, validation.method_name
+
+      proc = proc{ }
+      subject.validate(&proc)
+      validation = subject.validations.last
+      assert_equal :custom, validation.type
+      assert_equal proc,    validation.block
+    end
+
+    should "add a callback config with #after_initialize" do
+      subject.after_initialize :a_callback_method
+      callback = subject.callbacks.last
+      assert_equal :after_initialize, callback.type
+      assert_includes :a_callback_method, callback.args
     end
 
     should "add a callback config with #before_validation" do


### PR DESCRIPTION
#### Expand record spy to catch association configurations

This adds association configuration spying to the record spy. It
now catches `belongs_to`, `has_many` and `has_one` methods and
will allow inspecting the configuration.
#### Expand the record spy validations and callbacks

This adds `validate` to the validations and `after_initialize` to
the callbacks. This allows the record spy to spy on more of
ActiveRecord's configuration.
