### PR TITLE
Add all ActiveRecord validations and callbacks to `RecordSpy`

### DIFF
--- a/test/unit/record_spy_tests.rb
+++ b/test/unit/record_spy_tests.rb
@@ -17,9 +17,19 @@ module Ardb::RecordSpy
 
     should have_readers :associations, :callbacks, :validations
     should have_imeths :belongs_to, :has_many, :has_one
-    should have_imeths :validates_presence_of, :validates_uniqueness_of
-    should have_imeths :validates_inclusion_of, :validate
-    should have_imeths :after_initialize, :before_validation, :after_save
+    should have_imeths :validates_acceptance_of, :validates_confirmation_of
+    should have_imeths :validates_exclusion_of,  :validates_format_of
+    should have_imeths :validates_inclusion_of, :validates_length_of
+    should have_imeths :validates_numericality_of, :validates_presence_of
+    should have_imeths :validates_size_of, :validates_uniqueness_of
+    should have_imeths :validates_associated, :validates_with, :validates_each
+    should have_imeths :validate
+    should have_imeths :before_validation, :after_validation
+    should have_imeths :before_create,  :around_create,  :after_create
+    should have_imeths :before_update,  :around_update,  :after_update
+    should have_imeths :before_save,    :around_save,    :after_save
+    should have_imeths :before_destroy, :around_destroy, :after_destroy
+    should have_imeths :after_initialize, :after_find
 
     should "included the record spy instance methods" do
       assert_includes Ardb::RecordSpy::InstanceMethods, subject.included_modules
@@ -53,25 +63,37 @@ module Ardb::RecordSpy
       subject.validates_presence_of :name, :email, :on => :create
       validation = subject.validations.last
       assert_equal :presence, validation.type
-      assert_includes :name, validation.columns
+      assert_equal :create,   validation.options[:on]
+      assert_includes :name,  validation.columns
       assert_includes :email, validation.columns
-      assert_equal :create, validation.options[:on]
     end
 
-    should "add a validation config with #validates_uniqueness_of" do
-      subject.validates_uniqueness_of :name, :scope => :area_id
+    should "add a validation config with #validates_associated" do
+      subject.validates_associated :area, :linkings
       validation = subject.validations.last
-      assert_equal :uniqueness, validation.type
-      assert_includes :name, validation.columns
-      assert_equal :area_id, validation.options[:scope]
+      assert_equal :associated, validation.type
+      assert_includes :area,     validation.associations
+      assert_includes :linkings, validation.associations
     end
 
-    should "add a validation config with #validates_inclusion_of" do
-      subject.validates_inclusion_of :active, :in => [ true, false]
+    should "add a validation config with #validates_associated" do
+      first_validation_class  = Class.new
+      second_validation_class = Class.new
+      subject.validates_with first_validation_class, second_validation_class
       validation = subject.validations.last
-      assert_equal :inclusion, validation.type
-      assert_includes :active, validation.columns
-      assert_equal [ true, false], validation.options[:in]
+      assert_equal :with, validation.type
+      assert_includes first_validation_class,  validation.classes
+      assert_includes second_validation_class, validation.classes
+    end
+
+    should "add a validation config with #validates_each" do
+      block = proc{ }
+      subject.validates_each(:name, :email, &block)
+      validation = subject.validations.last
+      assert_equal :each, validation.type
+      assert_equal block, validation.block
+      assert_includes :name,  validation.columns
+      assert_includes :email, validation.columns
     end
 
     should "add a validation config with #validate" do
@@ -80,11 +102,11 @@ module Ardb::RecordSpy
       assert_equal :custom,      validation.type
       assert_equal :some_method, validation.method_name
 
-      proc = proc{ }
-      subject.validate(&proc)
+      block = proc{ }
+      subject.validate(&block)
       validation = subject.validations.last
       assert_equal :custom, validation.type
-      assert_equal proc,    validation.block
+      assert_equal block,    validation.block
     end
 
     should "add a callback config with #after_initialize" do
@@ -103,13 +125,6 @@ module Ardb::RecordSpy
       assert_equal :create, callback.options[:on]
       @instance.instance_eval(&callback.block)
       assert_equal 'test', @instance.name
-    end
-
-    should "add a callback config with #after_save" do
-      subject.after_save :a_callback_method
-      callback = subject.callbacks.last
-      assert_equal :after_save, callback.type
-      assert_includes :a_callback_method, callback.args
     end
 
   end


### PR DESCRIPTION
This adds all of ActiveRecord's validations and callbacks to the
`RecordSpy`. This probably should've been done earlier, instead
of adding them as needed, but this should cover what ActiveRecord
currently provides.

@kellyredding - Should of gone ahead and done this. After I rolled the current version I found a case where I needed `after_destroy`, so I decided I should just add them all so I don't have to keep rolling versions.
