### PR TITLE
ensure that `reset_db` runs only once by default

### DIFF
--- a/lib/ardb/test_helpers.rb
+++ b/lib/ardb/test_helpers.rb
@@ -20,10 +20,17 @@ module Ardb::TestHelpers
     $stdout = current_stdout
   end
 
-  def reset_db
+  def reset_db!
     Ardb.adapter.drop_db
     Ardb.adapter.create_db
     self.load_schema
+  end
+
+  def reset_db
+    @reset_db ||= begin
+      self.reset_db!
+      true
+    end
   end
 
 end

--- a/test/unit/test_helpers_tests.rb
+++ b/test/unit/test_helpers_tests.rb
@@ -7,7 +7,7 @@ module Ardb::TestHelpers
     desc "Ardb test helpers"
     subject{ Ardb::TestHelpers }
 
-    should have_imeths :drop_tables, :load_schema, :reset_db
+    should have_imeths :drop_tables, :load_schema, :reset_db, :reset_db!
 
   end
 


### PR DESCRIPTION
Use `reset_db!` to force additional reloads.  This is to ensure
that in standard testing the db is reset only once per test run.
This helps ensure the tests are as fast as possible.

**Note**: this needs better testing.  To do that, though, I want
to add an "adapter spy" object to test with.  This involves more
changes than I want to put in this PR.  I will follow this up with
better testing in the next PR.

@jcredding ready for review.
