### PR TITLE
have the base adapter define `load_schema`

### DIFF
--- a/lib/ardb/adapter/base.rb
+++ b/lib/ardb/adapter/base.rb
@@ -17,6 +17,14 @@ class Ardb::Adapter::Base
 
   def drop_tables(*args); raise NotImplementedError; end
 
+  def load_schema
+    # silence STDOUT
+    current_stdout = $stdout.dup
+    $stdout = File.new('/dev/null', 'w')
+    load Ardb.config.schema_path
+    $stdout = current_stdout
+  end
+
   def ==(other_adapter)
     self.class == other_adapter.class
   end

--- a/lib/ardb/test_helpers.rb
+++ b/lib/ardb/test_helpers.rb
@@ -13,11 +13,7 @@ module Ardb::TestHelpers
   end
 
   def load_schema
-    # silence STDOUT
-    current_stdout = $stdout.dup
-    $stdout = File.new('/dev/null', 'w')
-    load Ardb.config.schema_path
-    $stdout = current_stdout
+    Ardb.adapter.load_schema
   end
 
   def reset_db!

--- a/test/unit/adapter/base_tests.rb
+++ b/test/unit/adapter/base_tests.rb
@@ -12,7 +12,7 @@ class Ardb::Adapter::Base
 
     should have_reader :config_settings, :database
     should have_imeths :foreign_key_add_sql, :foreign_key_drop_sql
-    should have_imeths :create_db, :drop_db
+    should have_imeths :create_db, :drop_db, :load_schema
 
     should "use the config's db settings " do
       assert_equal Ardb.config.db_settings, subject.config_settings
@@ -34,6 +34,34 @@ class Ardb::Adapter::Base
 
     should "not implement the drop table methods" do
       assert_raises(NotImplementedError) { subject.drop_tables }
+    end
+
+  end
+
+  class LoadSchemaTests < BaseTests
+    desc "given a schema"
+    setup do
+      ::FAKE_SCHEMA_LOAD = OpenStruct.new(:count => 0)
+      @orig_schema_path = Ardb.config.schema_path
+      Ardb.config.schema_path = 'fake_schema.rb'
+    end
+    teardown do
+      Ardb.config.schema_path = @orig_schema_path
+    end
+
+    should "load the schema suppressing $stdout" do
+      orig_stdout = $stdout.dup
+      captured_stdout = ""
+      $stdout = StringIO.new(captured_stdout)
+
+      assert_equal 0, FAKE_SCHEMA_LOAD.count
+      subject.load_schema
+      assert_equal 1, FAKE_SCHEMA_LOAD.count
+      subject.load_schema
+      assert_equal 2, FAKE_SCHEMA_LOAD.count
+      assert_empty captured_stdout
+
+      $stdout = orig_stdout
     end
 
   end

--- a/tmp/testdb/fake_schema.rb
+++ b/tmp/testdb/fake_schema.rb
@@ -1,0 +1,3 @@
+puts "This should be suppressed!!"
+
+::FAKE_SCHEMA_LOAD.count += 1


### PR DESCRIPTION
This moves the load schema logic down to the base adapter.  It is
handy to centralize db interaction in the adapters, and this interaction
is common to all adapters.

This will allow us to better test the test helpers using an adapter
spy.

@jcredding ready for review.
