### PR TITLE
adding an `AdapterSpy`; use to test `TestHelpers`

### DIFF
--- a/lib/ardb.rb
+++ b/lib/ardb.rb
@@ -65,7 +65,7 @@ module Ardb
   class Adapter
     include Singleton
 
-    attr_reader :current
+    attr_accessor :current
 
     def init
       @current = Adapter.send(Ardb.config.db.adapter)

--- a/lib/ardb/adapter_spy.rb
+++ b/lib/ardb/adapter_spy.rb
@@ -1,0 +1,59 @@
+module Ardb
+
+  module AdapterSpy
+
+    def self.new(&block)
+      block ||= proc{ }
+      record_spy = Class.new{ include Ardb::AdapterSpy }
+      record_spy.class_eval(&block)
+      record_spy
+    end
+
+    def self.included(klass)
+      klass.class_eval do
+        include InstanceMethods
+      end
+    end
+
+    module InstanceMethods
+
+      attr_accessor :drop_tables_called_count, :load_schema_called_count
+      attr_accessor :drop_db_called_count, :create_db_called_count
+
+      def drop_tables_called_count
+        @drop_tables_called_count ||= 0
+      end
+
+      def drop_tables(*args, &block)
+        self.drop_tables_called_count += 1
+      end
+
+      def load_schema_called_count
+        @load_schema_called_count ||= 0
+      end
+
+      def load_schema(*args, &block)
+        self.load_schema_called_count += 1
+      end
+
+      def drop_db_called_count
+        @drop_db_called_count ||= 0
+      end
+
+      def drop_db(*args, &block)
+        self.drop_db_called_count += 1
+      end
+
+      def create_db_called_count
+        @create_db_called_count ||= 0
+      end
+
+      def create_db(*args, &block)
+        self.create_db_called_count += 1
+      end
+
+    end
+
+  end
+
+end

--- a/test/unit/adapter_spy_tests.rb
+++ b/test/unit/adapter_spy_tests.rb
@@ -1,0 +1,66 @@
+require 'assert'
+require 'ardb/adapter_spy'
+
+module Ardb::AdapterSpy
+
+  class MyAdapter
+    include Ardb::AdapterSpy
+  end
+
+  class BaseTests < Assert::Context
+    desc "Ardb::AdapterSpy"
+    setup do
+      @adapter = MyAdapter.new
+    end
+    subject{ @adapter }
+
+    should have_accessors :drop_tables_called_count, :load_schema_called_count
+    should have_accessors :drop_db_called_count, :create_db_called_count
+    should have_imeths :drop_tables, :load_schema, :drop_db, :create_db
+
+    should "included the record spy instance methods" do
+      assert_includes Ardb::AdapterSpy::InstanceMethods, subject.class.included_modules
+    end
+
+    should "default all call counts to zero" do
+      assert_equal 0, subject.drop_tables_called_count
+      assert_equal 0, subject.load_schema_called_count
+      assert_equal 0, subject.drop_db_called_count
+      assert_equal 0, subject.create_db_called_count
+    end
+
+    should "add a call count when each method is called" do
+      subject.drop_tables
+      assert_equal 1, subject.drop_tables_called_count
+
+      subject.load_schema
+      assert_equal 1, subject.load_schema_called_count
+
+      subject.drop_db
+      assert_equal 1, subject.drop_db_called_count
+
+      subject.create_db
+      assert_equal 1, subject.create_db_called_count
+    end
+
+  end
+
+  class NewMethTests < BaseTests
+    desc "`new` method"
+    setup do
+      @adapter_spy_class = Ardb::AdapterSpy.new do
+        attr_accessor :name
+      end
+      @adapter = @adapter_spy_class.new
+    end
+    subject{ @adapter }
+
+    should "build a new spy class and use any custom definition" do
+      assert_includes Ardb::AdapterSpy, subject.class.included_modules
+      assert subject.respond_to? :name
+      assert subject.respond_to? :name=
+    end
+
+  end
+
+end

--- a/test/unit/test_helpers_tests.rb
+++ b/test/unit/test_helpers_tests.rb
@@ -11,4 +11,79 @@ module Ardb::TestHelpers
 
   end
 
+  class UsageTests < BaseTests
+    setup do
+      @adapter_spy_class = Ardb::AdapterSpy.new
+      @orig_ardb_adapter = Ardb.adapter
+      Ardb::Adapter.current = @adapter_spy = @adapter_spy_class.new
+    end
+    teardown do
+      Ardb::Adapter.current = @orig_ardb_adapter
+    end
+
+  end
+
+  class DropTablesTests < UsageTests
+    desc "`drop_tables` method"
+
+    should "tell the adapter to drop the tables" do
+      assert_equal 0, @adapter_spy.drop_tables_called_count
+      subject.drop_tables
+      assert_equal 1, @adapter_spy.drop_tables_called_count
+    end
+
+  end
+
+  class LoadSchemaTests < UsageTests
+    desc "`load_schema` method"
+
+    should "tell the adapter to load the schema" do
+      assert_equal 0, @adapter_spy.load_schema_called_count
+      subject.load_schema
+      assert_equal 1, @adapter_spy.load_schema_called_count
+    end
+
+  end
+
+  class ResetDbTests < UsageTests
+    desc "reset db methods"
+
+    should "tell the adapter to drop/create the db and load the schema only once" do
+      assert_equal 0, @adapter_spy.drop_db_called_count
+      assert_equal 0, @adapter_spy.create_db_called_count
+      assert_equal 0, @adapter_spy.load_schema_called_count
+
+      subject.reset_db
+
+      assert_equal 1, @adapter_spy.drop_db_called_count
+      assert_equal 1, @adapter_spy.create_db_called_count
+      assert_equal 1, @adapter_spy.load_schema_called_count
+
+      subject.reset_db
+
+      assert_equal 1, @adapter_spy.drop_db_called_count
+      assert_equal 1, @adapter_spy.create_db_called_count
+      assert_equal 1, @adapter_spy.load_schema_called_count
+    end
+
+    should "force the adapter to drop/create the db and load the schema" do
+      assert_equal 0, @adapter_spy.drop_db_called_count
+      assert_equal 0, @adapter_spy.create_db_called_count
+      assert_equal 0, @adapter_spy.load_schema_called_count
+
+      subject.reset_db!
+
+      assert_equal 1, @adapter_spy.drop_db_called_count
+      assert_equal 1, @adapter_spy.create_db_called_count
+      assert_equal 1, @adapter_spy.load_schema_called_count
+
+      subject.reset_db!
+
+      assert_equal 2, @adapter_spy.drop_db_called_count
+      assert_equal 2, @adapter_spy.create_db_called_count
+      assert_equal 2, @adapter_spy.load_schema_called_count
+    end
+
+  end
+
 end


### PR DESCRIPTION
This adds formal tests for the `TestHelpers` methods.  To test the
helper methods in isolation, an `AdapterSpy` class is added
to spy on the adapter calls the test helpers make.

The main goal here is to test the test helpers methods.  The spy
class stuff is more of a side-effect of doing that.

@jcredding ready for review.  What do you think about the spy called count implementations?
