### PR TITLE
Record spies have an `id` accessor

### DIFF
--- a/lib/ardb/record_spy.rb
+++ b/lib/ardb/record_spy.rb
@@ -83,6 +83,8 @@ module Ardb
 
     module InstanceMethods
 
+      attr_accessor :id
+
       def update_column(col, value)
         self.send("#{col}=", value)
       end

--- a/test/unit/record_spy_tests.rb
+++ b/test/unit/record_spy_tests.rb
@@ -147,6 +147,7 @@ module Ardb::RecordSpy
   class InstanceTests < UnitTests
     subject{ @instance }
 
+    should have_accessors :id
     should have_imeths :update_column
 
     should "allow spying the update_column method by just writing the value" do


### PR DESCRIPTION
This updates the record spies to add an `id` accessor.  This more
closely matches an active record object that we are spying on.

@jcredding ready for review.
