### PR TITLE
Add a relation spy

### DIFF
--- a/lib/ardb/relation_spy.rb
+++ b/lib/ardb/relation_spy.rb
@@ -1,0 +1,64 @@
+module Ardb
+
+  class RelationSpy
+
+    attr_reader :applied
+    attr_accessor :results
+
+    def initialize
+      @applied, @results = [], []
+      @offset, @limit = 0, nil
+    end
+
+    [ :select,
+      :joins,
+      :where,
+      :order,
+      :group, :having,
+      :merge
+    ].each do |type|
+
+      define_method(type) do |*args|
+        @applied << AppliedExpression.new(type, args)
+        self
+      end
+
+    end
+
+    def limit(value)
+      @limit = value ? value.to_i : nil
+      @applied << AppliedExpression.new(:limit, [ value ])
+      self
+    end
+
+    def offset(value)
+      @offset = value ? value.to_i : 0
+      @applied << AppliedExpression.new(:offset, [ value ])
+      self
+    end
+
+    def all
+      @results[@offset, (@limit || @results.size)] || []
+    end
+
+    def count
+      all.size
+    end
+
+    def limit_value
+      @limit
+    end
+
+    def offset_value
+      @offset
+    end
+
+    def ==(other)
+      @applied == other.applied
+    end
+
+    AppliedExpression = Struct.new(:type, :args)
+
+  end
+
+end

--- a/test/unit/relation_spy_tests.rb
+++ b/test/unit/relation_spy_tests.rb
@@ -1,0 +1,160 @@
+require 'assert'
+require 'ardb/relation_spy'
+
+class Ardb::RelationSpy
+
+  class UnitTests < Assert::Context
+    desc "Ardb::RelationSpy"
+    setup do
+      @relation_spy = Ardb::RelationSpy.new
+    end
+    subject{ @relation_spy }
+
+    should have_readers :applied
+    should have_accessors :results
+    should have_imeths :select, :joins, :where, :order, :group, :having, :merge
+    should have_imeths :limit, :offset
+    should have_imeths :all, :count
+    should have_imeths :limit_value, :offset_value
+
+    should "default it's attributes" do
+      assert_equal [],  subject.applied
+      assert_equal [],  subject.results
+      assert_equal nil, subject.limit_value
+      assert_equal 0,   subject.offset_value
+    end
+
+    should "add an applied expression using `select`" do
+      subject.select :column_a, :column_b
+      assert_equal 1, subject.applied.size
+      applied_expression = subject.applied.first
+      assert_instance_of AppliedExpression, applied_expression
+      assert_equal :select, applied_expression.type
+      assert_equal [ :column_a, :column_b ], applied_expression.args
+    end
+
+    should "add an applied expression using `joins`" do
+      subject.joins :table_a, :table_b
+      assert_equal 1, subject.applied.size
+      applied_expression = subject.applied.first
+      assert_instance_of AppliedExpression, applied_expression
+      assert_equal :joins, applied_expression.type
+      assert_equal [ :table_a, :table_b ], applied_expression.args
+    end
+
+    should "add an applied expression using `where`" do
+      subject.where :column_a => 'some value'
+      assert_equal 1, subject.applied.size
+      applied_expression = subject.applied.first
+      assert_instance_of AppliedExpression, applied_expression
+      assert_equal :where, applied_expression.type
+      assert_equal [ { :column_a => 'some value' } ], applied_expression.args
+    end
+
+    should "add an applied expression using `order`" do
+      subject.order :column_a, :column_b
+      assert_equal 1, subject.applied.size
+      applied_expression = subject.applied.first
+      assert_instance_of AppliedExpression, applied_expression
+      assert_equal :order, applied_expression.type
+      assert_equal [ :column_a, :column_b ], applied_expression.args
+    end
+
+    should "add an applied expression using `group`" do
+      subject.group :column_a, :column_b
+      assert_equal 1, subject.applied.size
+      applied_expression = subject.applied.first
+      assert_instance_of AppliedExpression, applied_expression
+      assert_equal :group, applied_expression.type
+      assert_equal [ :column_a, :column_b ], applied_expression.args
+    end
+
+    should "add an applied expression using `having`" do
+      subject.having 'COUNT(column_a) > 0'
+      assert_equal 1, subject.applied.size
+      applied_expression = subject.applied.first
+      assert_instance_of AppliedExpression, applied_expression
+      assert_equal :having, applied_expression.type
+      assert_equal [ 'COUNT(column_a) > 0' ], applied_expression.args
+    end
+
+    should "add an applied expression using `merge`" do
+      other_relation = Ardb::RelationSpy.new
+      subject.merge other_relation
+      assert_equal 1, subject.applied.size
+      applied_expression = subject.applied.first
+      assert_instance_of AppliedExpression, applied_expression
+      assert_equal :merge, applied_expression.type
+      assert_equal [ other_relation ], applied_expression.args
+    end
+
+    should "add an applied expression using `limit`" do
+      subject.limit 100
+      assert_equal 1, subject.applied.size
+      applied_expression = subject.applied.first
+      assert_instance_of AppliedExpression, applied_expression
+      assert_equal :limit, applied_expression.type
+      assert_equal [ 100 ], applied_expression.args
+    end
+
+    should "set it's limit value using `limit`" do
+      subject.limit 100
+      assert_equal 100, subject.limit_value
+    end
+
+    should "add an applied expression using `offset`" do
+      subject.offset 100
+      assert_equal 1, subject.applied.size
+      applied_expression = subject.applied.first
+      assert_instance_of AppliedExpression, applied_expression
+      assert_equal :offset, applied_expression.type
+      assert_equal [ 100 ], applied_expression.args
+    end
+
+    should "set it's offset value using `offset`" do
+      subject.offset 100
+      assert_equal 100, subject.offset_value
+    end
+
+    should "return it's results using `all`" do
+      subject.results = [ 1, 2, 3 ]
+      assert_equal [ 1, 2, 3 ], subject.all
+    end
+
+    should "honor limit and offset values using `all`" do
+      subject.results = [ 1, 2, 3, 4, 5 ]
+
+      subject.limit 2
+      subject.offset nil
+      assert_equal [ 1, 2 ], subject.all
+
+      subject.limit nil
+      subject.offset 3
+      assert_equal [ 4, 5 ], subject.all
+
+      subject.limit 2
+      subject.offset 2
+      assert_equal [ 3, 4 ], subject.all
+    end
+
+    should "return the size of `all` using `count`" do
+      subject.results = [ 1, 2, 3, 4, 5 ]
+      assert_equal 5, subject.count
+
+      subject.limit 2
+      subject.offset 2
+      assert_equal 2, subject.count
+    end
+
+    should "be comparable using there applied collections" do
+      other_relation = Ardb::RelationSpy.new
+      other_relation.select :column_a
+      assert_not_equal other_relation, subject
+
+      subject.select :column_a
+      assert_equal other_relation, subject
+    end
+
+  end
+
+end


### PR DESCRIPTION
This adds a relation spy to Ardb for testing things that
manipulate ActiveRecord relations. This spy will collect
ActiveRecord query expressions and will store them in a
collection for inspection. The spy will also properly fake the
`all` and `count` methods. These will honor limit and offset
values that have been applied. This is tool for testing and can
injected into a system to see what kind of ActiveRecord relation's
it builds.
