### PR TITLE
Expand `Ardb::RelationSpy`, add order values accessors

### DIFF
--- a/lib/ardb/relation_spy.rb
+++ b/lib/ardb/relation_spy.rb
@@ -3,17 +3,20 @@ module Ardb
   class RelationSpy
 
     attr_reader :applied
+    attr_accessor :order_values, :reverse_order_value
+    attr_accessor :limit_value, :offset_value
     attr_accessor :results
 
     def initialize
       @applied, @results = [], []
-      @offset, @limit = 0, nil
+      @order_values = []
+      @reverse_order_value = nil
+      @offset_value, @limit_value = nil, nil
     end
 
     [ :select,
       :joins,
       :where,
-      :order,
       :group, :having,
       :merge
     ].each do |type|
@@ -25,32 +28,30 @@ module Ardb
 
     end
 
+    def order(*args)
+      @order_values += args
+      @applied << AppliedExpression.new(:order, args)
+      self
+    end
+
     def limit(value)
-      @limit = value ? value.to_i : nil
+      @limit_value = value ? value.to_i : nil
       @applied << AppliedExpression.new(:limit, [ value ])
       self
     end
 
     def offset(value)
-      @offset = value ? value.to_i : 0
+      @offset_value = value ? value.to_i : 0
       @applied << AppliedExpression.new(:offset, [ value ])
       self
     end
 
     def all
-      @results[@offset, (@limit || @results.size)] || []
+      @results[(@offset_value || 0), (@limit_value || @results.size)] || []
     end
 
     def count
       all.size
-    end
-
-    def limit_value
-      @limit
-    end
-
-    def offset_value
-      @offset
     end
 
     def ==(other)

--- a/test/unit/relation_spy_tests.rb
+++ b/test/unit/relation_spy_tests.rb
@@ -12,16 +12,19 @@ class Ardb::RelationSpy
 
     should have_readers :applied
     should have_accessors :results
+    should have_accessors :order_values, :reverse_order_value
+    should have_accessors :limit_value, :offset_value
     should have_imeths :select, :joins, :where, :order, :group, :having, :merge
     should have_imeths :limit, :offset
     should have_imeths :all, :count
-    should have_imeths :limit_value, :offset_value
 
     should "default it's attributes" do
       assert_equal [],  subject.applied
       assert_equal [],  subject.results
+      assert_equal [],  subject.order_values
+      assert_equal nil, subject.reverse_order_value
       assert_equal nil, subject.limit_value
-      assert_equal 0,   subject.offset_value
+      assert_equal nil, subject.offset_value
     end
 
     should "add an applied expression using `select`" do
@@ -58,6 +61,12 @@ class Ardb::RelationSpy
       assert_instance_of AppliedExpression, applied_expression
       assert_equal :order, applied_expression.type
       assert_equal [ :column_a, :column_b ], applied_expression.args
+    end
+
+    should "add args to it's `order_values` using `order" do
+      subject.order :column_a, :column_b
+      assert_includes :column_a, subject.order_values
+      assert_includes :column_b, subject.order_values
     end
 
     should "add an applied expression using `group`" do


### PR DESCRIPTION
This updates the `Ardb::RelationSpy` to allow accessing the order
value accessors. These are more `ActiveRecord::Relation` methods.
This also changed the `order` method to add to the `order_values`,
which mimics ActiveRecord's behavior. Finally, this also tweaked
the `limit_value` and `offset_value`. `offset_value` is now
defaulted to `nil` which more correctly mimics ActiveRecord. This
is all to expand the relation spy so it can be used for more
testing scenarios.

@kellyredding - I'm adding this for MR. I need to set the order values accessors in my implementation for redding/mr#142.
