### PR TITLE
Updates to support Ruby 2.0, 2.1 and Rubinius 2.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,8 @@ gemspec
 
 gem 'rake'
 gem 'pry'
+
+platform :rbx do
+  gem 'rubysl'
+end
+

--- a/lib/ardb/runner.rb
+++ b/lib/ardb/runner.rb
@@ -15,6 +15,7 @@ class Ardb::Runner
   end
 
   def run
+    $LOAD_PATH.push(Dir.pwd) unless $LOAD_PATH.include?(Dir.pwd)
     Ardb.init(false) # don't establish a connection
 
     case @cmd_name

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -52,6 +52,12 @@ class Ardb::Runner
       ActiveRecord::Base.logger = default_ar_logger
     end
 
+    should "add the working directory to the load paths" do
+      $LOAD_PATH.delete(Dir.pwd)
+      subject.run
+      assert_includes Dir.pwd, $LOAD_PATH
+    end
+
     should "complain about unknown cmds" do
       runner = Ardb::Runner.new(['unknown'], {})
       assert_raises(UnknownCmdError) { runner.run }


### PR DESCRIPTION
This updates Ardb to support Ruby 2.0, 2.1 and Rubinius 2.2. This
didn't require any major changes to Ardb's source. It only
required adding the Rubinius `ruby-sl` to the Gemfile.

This also updates the `Runner` and has it add the working
directory to the `$LOAD_PATH`. This is related to working with
Ruby versions greater than 1.8. Since Ruby 1.9, the working
directory is no longer added to the `$LOAD_PATH`. Thus, the
working directory needs to be added for Ardb commands so the
default isn't useless.
