### PR TITLE
Update `RelationSpy`, allow from expressions, tweak except/only

### DIFF
--- a/lib/ardb/relation_spy.rb
+++ b/lib/ardb/relation_spy.rb
@@ -11,6 +11,12 @@ module Ardb
       @offset_value, @limit_value = nil, nil
     end
 
+    def initialize_copy(copied_from)
+      super
+      @applied = copied_from.applied.dup
+      @results = copied_from.results.dup
+    end
+
     def ==(other)
       other.kind_of?(self.class) ? @applied == other.applied : super
     end
@@ -18,6 +24,7 @@ module Ardb
     # ActiveRecord::QueryMethods
 
     [ :select,
+      :from,
       :includes, :joins,
       :where,
       :group, :having,
@@ -58,18 +65,20 @@ module Ardb
 
     def except(*skips)
       skips = skips.map(&:to_sym)
-      @applied.reject!{ |a| skips.include?(a.type) }
-      @limit_value    = nil if skips.include?(:limit)
-      @offset_value   = nil if skips.include?(:offset)
-      self
+      self.dup.tap do |r|
+        r.applied.reject!{ |a| skips.include?(a.type) }
+        r.limit_value    = nil if skips.include?(:limit)
+        r.offset_value   = nil if skips.include?(:offset)
+      end
     end
 
     def only(*onlies)
       onlies = onlies.map(&:to_sym)
-      @applied.reject!{ |a| !onlies.include?(a.type) }
-      @limit_value    = nil unless onlies.include?(:limit)
-      @offset_value   = nil unless onlies.include?(:offset)
-      self
+      self.dup.tap do |r|
+        r.applied.reject!{ |a| !onlies.include?(a.type) }
+        r.limit_value    = nil unless onlies.include?(:limit)
+        r.offset_value   = nil unless onlies.include?(:offset)
+      end
     end
 
     # ActiveRecord::FinderMethods


### PR DESCRIPTION
This updates the `RelationSpy` to align it as a better spy for
`ActiveRecord::Relation`. This adds a `from` method that allows
applying "from" expressions and testing for those. This works
the same way the other expressions do. This also updates the
relation spy to better support duping/cloning. Previsouly, the
shallow copy that is the default for ruby objects would leave
2 spies sharing applied and results arrays. This updates them
to ensure they dup/clone these as well. This is used by the
`only` and `except` methods which now properly dup the relation
and return a new one with the modifications. This is how
ActiveRecord's methods work.

@kellyredding - This is needed to test some updates for MR related to counting grouped queries.
