### PR TITLE
Update `RelationSpy` to support `to_sql`

### DIFF
--- a/lib/ardb/relation_spy.rb
+++ b/lib/ardb/relation_spy.rb
@@ -21,6 +21,10 @@ module Ardb
       other.kind_of?(self.class) ? @applied == other.applied : super
     end
 
+    def to_sql
+      @applied.map(&:to_sql).join(", ")
+    end
+
     # ActiveRecord::QueryMethods
 
     [ :select,
@@ -114,7 +118,11 @@ module Ardb
       all.size
     end
 
-    AppliedExpression = Struct.new(:type, :args)
+    class AppliedExpression < Struct.new(:type, :args)
+      def to_sql
+        "#{self.type}: #{self.args.inspect}"
+      end
+    end
 
     NotFoundError = Class.new(RuntimeError)
 

--- a/test/unit/relation_spy_tests.rb
+++ b/test/unit/relation_spy_tests.rb
@@ -13,6 +13,7 @@ class Ardb::RelationSpy
     should have_readers :applied
     should have_accessors :results
     should have_accessors :limit_value, :offset_value
+    should have_imeths :to_sql
     should have_imeths :select
     should have_imeths :from
     should have_imeths :includes, :joins
@@ -45,6 +46,15 @@ class Ardb::RelationSpy
 
       subject.select :column_a
       assert_equal other_relation, subject
+    end
+
+    should "build a fake sql string for its applied expressions using `to_sql`" do
+      subject.select 'column'
+      subject.from 'table'
+      subject.joins 'my_table.my_column ON my_table.my_column = table.column'
+
+      expected = subject.applied.map(&:to_sql).join(', ')
+      assert_equal expected, subject.to_sql
     end
 
   end
@@ -444,6 +454,23 @@ class Ardb::RelationSpy
       assert_equal subject.all.size, subject.count
       subject.limit 2
       assert_equal subject.all.size, subject.count
+    end
+
+  end
+
+  class AppliedExpressionTests < UnitTests
+    desc "AppliedExpression"
+    setup do
+      @applied_expression = AppliedExpression.new(:select, 'column')
+    end
+    subject{ @applied_expression }
+
+    should have_readers :type, :args
+    should have_imeths :to_sql
+
+    should "return a string representing the expression using `to_sql`" do
+      expected = "#{subject.type}: #{subject.args.inspect}"
+      assert_equal expected, subject.to_sql
     end
 
   end


### PR DESCRIPTION
This updates the `RelationSpy` to support ActiveRecord's `to_sql`
method. This is to support more of ActiveRecord's relation
interface for tools using this method. This method is primarily
intended to support tools using this to create complex SQL queries
with subqueries or possibly unions. This creates a simple string
representing the applied expressions. The string is not actual
SQL.

@kellyredding - Ready for review. I need this for MR subquery testing. 
