### PR TITLE
Cleanups to the test suite

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 gem 'rake'
-gem 'pry'
+gem 'pry', "~> 0.9.0"
 
 platform :rbx do
   gem 'rubysl'

--- a/ardb.gemspec
+++ b/ardb.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency("assert", ["~> 2.0"])
+  gem.add_development_dependency("assert", ["~> 2.10"])
 
   gem.add_dependency('activerecord',  ["~> 3.2"])
   gem.add_dependency('activesupport', ["~> 3.2"])

--- a/test/unit/adapter/base_tests.rb
+++ b/test/unit/adapter/base_tests.rb
@@ -3,42 +3,42 @@ require 'ardb/adapter/base'
 
 class Ardb::Adapter::Base
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "Ardb::Adapter::Base"
     setup do
       @adapter = Ardb::Adapter::Base.new
     end
     subject { @adapter }
 
-    should have_reader :config_settings, :database
+    should have_readers :config_settings, :database
     should have_imeths :foreign_key_add_sql, :foreign_key_drop_sql
     should have_imeths :create_db, :drop_db, :load_schema
 
-    should "use the config's db settings " do
+    should "know its config settings " do
       assert_equal Ardb.config.db_settings, subject.config_settings
     end
 
-    should "use the config's database" do
+    should "know its database" do
       assert_equal Ardb.config.db.database, subject.database
     end
 
     should "not implement the foreign key sql meths" do
-      assert_raises(NotImplementedError) { subject.foreign_key_add_sql }
-      assert_raises(NotImplementedError) { subject.foreign_key_drop_sql }
+      assert_raises(NotImplementedError){ subject.foreign_key_add_sql }
+      assert_raises(NotImplementedError){ subject.foreign_key_drop_sql }
     end
 
     should "not implement the create and drop db methods" do
-      assert_raises(NotImplementedError) { subject.create_db }
-      assert_raises(NotImplementedError) { subject.drop_db }
+      assert_raises(NotImplementedError){ subject.create_db }
+      assert_raises(NotImplementedError){ subject.drop_db }
     end
 
     should "not implement the drop table methods" do
-      assert_raises(NotImplementedError) { subject.drop_tables }
+      assert_raises(NotImplementedError){ subject.drop_tables }
     end
 
   end
 
-  class LoadSchemaTests < BaseTests
+  class LoadSchemaTests < UnitTests
     desc "given a schema"
     setup do
       ::FAKE_SCHEMA_LOAD = OpenStruct.new(:count => 0)

--- a/test/unit/adapter/mysql_tests.rb
+++ b/test/unit/adapter/mysql_tests.rb
@@ -3,7 +3,7 @@ require 'ardb/adapter/mysql'
 
 class Ardb::Adapter::Mysql
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "Ardb::Adapter::Mysql"
     setup do
       @adapter = Ardb::Adapter::Mysql.new
@@ -26,13 +26,13 @@ class Ardb::Adapter::Mysql
 
     # not currently implemented, see: https://github.com/redding/ardb/issues/13
     should "not implement the create and drop db methods" do
-      assert_raises(NotImplementedError) { subject.create_db }
-      assert_raises(NotImplementedError) { subject.drop_db }
+      assert_raises(NotImplementedError){ subject.create_db }
+      assert_raises(NotImplementedError){ subject.drop_db }
     end
 
     # not currently implemented, see: https://github.com/redding/ardb/issues/28
     should "not implement the drop tables method" do
-      assert_raises(NotImplementedError) { subject.drop_tables }
+      assert_raises(NotImplementedError){ subject.drop_tables }
     end
 
   end

--- a/test/unit/adapter/postgresql_tests.rb
+++ b/test/unit/adapter/postgresql_tests.rb
@@ -3,16 +3,16 @@ require 'ardb/adapter/postgresql'
 
 class Ardb::Adapter::Postgresql
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "Ardb::Adapter::Postgresql"
     setup do
       @adapter = Ardb::Adapter::Postgresql.new
     end
     subject { @adapter }
 
-    should have_instance_method :public_schema_settings
+    should have_imeths :public_schema_settings
 
-    should "know it's public schema connection settings" do
+    should "know its public schema connection settings" do
       exp_settings = subject.config_settings.merge({
         'database' => 'postgres',
         'schema_search_path' => 'public'

--- a/test/unit/adapter/sqlite_tests.rb
+++ b/test/unit/adapter/sqlite_tests.rb
@@ -3,7 +3,7 @@ require 'ardb/adapter/sqlite'
 
 class Ardb::Adapter::Sqlite
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "Ardb::Adapter::Sqlite"
     setup do
       @adapter = Ardb::Adapter::Sqlite.new
@@ -19,19 +19,19 @@ class Ardb::Adapter::Sqlite
       FileUtils.rm(subject.db_file_path)
     end
 
-    should "know its db_file_path" do
+    should "know its db file path" do
       exp_path = Ardb.config.root_path.join(Ardb.config.db.database).to_s
       assert_equal exp_path, subject.db_file_path
     end
 
     should "not implement the foreign key sql meths" do
-      assert_raises(NotImplementedError) { subject.foreign_key_add_sql }
-      assert_raises(NotImplementedError) { subject.foreign_key_drop_sql }
+      assert_raises(NotImplementedError){ subject.foreign_key_add_sql }
+      assert_raises(NotImplementedError){ subject.foreign_key_drop_sql }
     end
 
     # not currently implemented, see: https://github.com/redding/ardb/issues/29
     should "not implement the drop tables method" do
-      assert_raises(NotImplementedError) { subject.drop_tables }
+      assert_raises(NotImplementedError){ subject.drop_tables }
     end
 
   end

--- a/test/unit/adapter_spy_tests.rb
+++ b/test/unit/adapter_spy_tests.rb
@@ -7,7 +7,7 @@ module Ardb::AdapterSpy
     include Ardb::AdapterSpy
   end
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "Ardb::AdapterSpy"
     setup do
       @adapter = MyAdapter.new
@@ -19,7 +19,7 @@ module Ardb::AdapterSpy
     should have_imeths :drop_tables, :load_schema, :drop_db, :create_db
 
     should "included the record spy instance methods" do
-      assert_includes Ardb::AdapterSpy::InstanceMethods, subject.class.included_modules
+      assert_includes Ardb::AdapterSpy::InstanceMethods, subject.class
     end
 
     should "default all call counts to zero" do
@@ -45,7 +45,7 @@ module Ardb::AdapterSpy
 
   end
 
-  class NewMethTests < BaseTests
+  class NewMethTests < UnitTests
     desc "`new` method"
     setup do
       @adapter_spy_class = Ardb::AdapterSpy.new do
@@ -56,7 +56,7 @@ module Ardb::AdapterSpy
     subject{ @adapter }
 
     should "build a new spy class and use any custom definition" do
-      assert_includes Ardb::AdapterSpy, subject.class.included_modules
+      assert_includes Ardb::AdapterSpy, subject.class
       assert subject.respond_to? :name
       assert subject.respond_to? :name=
     end

--- a/test/unit/ardb_tests.rb
+++ b/test/unit/ardb_tests.rb
@@ -3,7 +3,7 @@ require 'ardb'
 
 module Ardb
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "Ardb"
     subject{ Ardb }
     setup do

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -1,11 +1,13 @@
 require 'assert'
-require 'ns-options/assert_macros'
 require 'ardb'
+
+require 'ns-options/assert_macros'
 
 class Ardb::Config
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     include NsOptions::AssertMacros
+
     desc "Ardb::Config"
     subject{ Ardb::Config }
 
@@ -37,7 +39,7 @@ class Ardb::Config
 
   end
 
-  class DbTests < BaseTests
+  class DbTests < UnitTests
     desc "db namespace"
     subject{ Ardb::Config.db }
 

--- a/test/unit/migration_helpers_tests.rb
+++ b/test/unit/migration_helpers_tests.rb
@@ -3,15 +3,15 @@ require 'ardb/migration_helpers'
 
 module Ardb::MigrationHelpers
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "Ardb migration helpers"
     subject{ Ardb::MigrationHelpers }
 
-    should have_instance_methods :foreign_key, :drop_foreign_key, :remove_column_with_fk
+    should have_imeths :foreign_key, :drop_foreign_key, :remove_column_with_fk
 
   end
 
-  class ForeignKeyTests < BaseTests
+  class ForeignKeyTests < UnitTests
     desc "ForeignKey handler"
     setup do
       @fk = ForeignKey.new('fromtbl', 'fromcol', 'totbl')
@@ -20,7 +20,7 @@ module Ardb::MigrationHelpers
 
     should have_readers :from_table, :from_column, :to_table, :to_column
     should have_readers :name, :adapter
-    should have_instance_methods :add_sql, :drop_sql
+    should have_imeths :add_sql, :drop_sql
 
     should "know its from table/column and to table" do
       assert_equal 'fromtbl', subject.from_table

--- a/test/unit/runner/connect_command_tests.rb
+++ b/test/unit/runner/connect_command_tests.rb
@@ -3,14 +3,14 @@ require 'ardb/runner/connect_command'
 
 class Ardb::Runner::CreateCommand
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "Ardb::Runner::ConnectCommand"
     setup do
       @cmd = Ardb::Runner::ConnectCommand.new
     end
     subject{ @cmd }
 
-    should have_instance_methods :run
+    should have_imeths :run
 
   end
 

--- a/test/unit/runner/create_command_tests.rb
+++ b/test/unit/runner/create_command_tests.rb
@@ -3,14 +3,14 @@ require 'ardb/runner/create_command'
 
 class Ardb::Runner::CreateCommand
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "Ardb::Runner::CreateCommand"
     setup do
       @cmd = Ardb::Runner::CreateCommand.new
     end
     subject{ @cmd }
 
-    should have_instance_methods :run
+    should have_imeths :run
 
   end
 

--- a/test/unit/runner/drop_command_tests.rb
+++ b/test/unit/runner/drop_command_tests.rb
@@ -3,14 +3,14 @@ require 'ardb/runner/drop_command'
 
 class Ardb::Runner::DropCommand
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "Ardb::Runner::DropCommand"
     setup do
       @cmd = Ardb::Runner::DropCommand.new
     end
     subject{ @cmd }
 
-    should have_instance_methods :run
+    should have_imeths :run
 
   end
 

--- a/test/unit/runner/generate_command_tests.rb
+++ b/test/unit/runner/generate_command_tests.rb
@@ -3,18 +3,18 @@ require 'ardb/runner/generate_command'
 
 class Ardb::Runner::GenerateCommand
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "Ardb::Runner::GenerateCommand"
     setup do
       @cmd = Ardb::Runner::GenerateCommand.new(['something'])
     end
     subject{ @cmd }
 
-    should have_instance_methods :run, :migration_cmd
+    should have_imeths :run, :migration_cmd
 
   end
 
-  class MigrationTests < BaseTests
+  class MigrationTests < UnitTests
     desc "Ardb::Runner::GenerateCommand::MigrationCommand"
     setup do
       @cmd = Ardb::Runner::GenerateCommand::MigrationCommand.new('a_migration')

--- a/test/unit/runner/migrate_command_tests.rb
+++ b/test/unit/runner/migrate_command_tests.rb
@@ -3,7 +3,7 @@ require 'ardb/runner/migrate_command'
 
 class Ardb::Runner::MigrateCommand
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "Ardb::Runner::MigrateCommand"
     setup do
       @cmd = Ardb::Runner::MigrateCommand.new
@@ -27,7 +27,7 @@ class Ardb::Runner::MigrateCommand
 
   end
 
-  class VersionTests < BaseTests
+  class VersionTests < UnitTests
     desc "with a version ENV setting"
     setup do
       ENV["VERSION"] = '12345'
@@ -43,7 +43,7 @@ class Ardb::Runner::MigrateCommand
 
   end
 
-  class VerboseTests < BaseTests
+  class VerboseTests < UnitTests
     desc "with a verbose ENV setting"
     setup do
       ENV["VERBOSE"] = 'no'

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -1,11 +1,12 @@
 require 'assert'
-require 'pathname'
-require 'active_record'
 require 'ardb/runner'
+
+require 'active_record'
+require 'pathname'
 
 class Ardb::Runner
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "Ardb::Runner"
     setup do
       @runner = Ardb::Runner.new(['null', 1, 2], 'some' => 'opts')
@@ -22,7 +23,7 @@ class Ardb::Runner
 
   end
 
-  class RunTests < BaseTests
+  class RunTests < UnitTests
     desc "when running a command"
     setup do
       Ardb::Adapter.reset

--- a/test/unit/test_helpers_tests.rb
+++ b/test/unit/test_helpers_tests.rb
@@ -3,7 +3,7 @@ require 'ardb/test_helpers'
 
 module Ardb::TestHelpers
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "Ardb test helpers"
     subject{ Ardb::TestHelpers }
 
@@ -11,7 +11,7 @@ module Ardb::TestHelpers
 
   end
 
-  class UsageTests < BaseTests
+  class UsageTests < UnitTests
     setup do
       @adapter_spy_class = Ardb::AdapterSpy.new
       @orig_ardb_adapter = Ardb.adapter


### PR DESCRIPTION
This updates Ardb's test suite to our latest conventions and
makes sure it is using the latest assert as well. This primarily
renames the `BaseTests` to `UnitTests` but also does a few other
cleanups. This is prep for some new features and changes. This
gets them in the best state possible for this.

@kellyredding - Ready for review.
