### PR TITLE
Move schema dumping to the adapter, setup for sql schema format

### DIFF
--- a/lib/ardb/adapter/base.rb
+++ b/lib/ardb/adapter/base.rb
@@ -3,10 +3,12 @@ class Ardb::Adapter; end
 class Ardb::Adapter::Base
 
   attr_reader :config_settings, :database
+  attr_reader :schema_path
 
   def initialize
     @config_settings = Ardb.config.db_settings
     @database = Ardb.config.db.database
+    @schema_path = Ardb.config.schema_path
   end
 
   def foreign_key_add_sql(*args);  raise NotImplementedError; end
@@ -21,8 +23,36 @@ class Ardb::Adapter::Base
     # silence STDOUT
     current_stdout = $stdout.dup
     $stdout = File.new('/dev/null', 'w')
-    load Ardb.config.schema_path
+    load_ruby_schema
     $stdout = current_stdout
+  end
+
+  def load_ruby_schema
+    load @schema_path
+  end
+
+  def load_sql_schema
+    raise NotImplementedError
+  end
+
+  def dump_schema
+    # silence STDOUT
+    current_stdout = $stdout.dup
+    $stdout = File.new('/dev/null', 'w')
+    dump_ruby_schema
+    $stdout = current_stdout
+  end
+
+  def dump_ruby_schema
+    require 'active_record/schema_dumper'
+    FileUtils.mkdir_p File.dirname(@schema_path)
+    File.open(@schema_path, 'w:utf-8') do |file|
+      ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection, file)
+    end
+  end
+
+  def dump_sql_schema
+    raise NotImplementedError
   end
 
   def ==(other_adapter)

--- a/test/unit/adapter/base_tests.rb
+++ b/test/unit/adapter/base_tests.rb
@@ -8,11 +8,14 @@ class Ardb::Adapter::Base
     setup do
       @adapter = Ardb::Adapter::Base.new
     end
-    subject { @adapter }
+    subject{ @adapter }
 
     should have_readers :config_settings, :database
+    should have_readers :schema_path
     should have_imeths :foreign_key_add_sql, :foreign_key_drop_sql
-    should have_imeths :create_db, :drop_db, :load_schema
+    should have_imeths :create_db, :drop_db
+    should have_imeths :load_schema, :load_ruby_schema, :load_sql_schema
+    should have_imeths :dump_schema, :dump_ruby_schema, :dump_sql_schema
 
     should "know its config settings " do
       assert_equal Ardb.config.db_settings, subject.config_settings
@@ -20,6 +23,10 @@ class Ardb::Adapter::Base
 
     should "know its database" do
       assert_equal Ardb.config.db.database, subject.database
+    end
+
+    should "know its schema path" do
+      assert_equal Ardb.config.schema_path, subject.schema_path
     end
 
     should "not implement the foreign key sql meths" do
@@ -36,34 +43,89 @@ class Ardb::Adapter::Base
       assert_raises(NotImplementedError){ subject.drop_tables }
     end
 
+    should "not implement the load and dump sql schema methods" do
+      assert_raises(NotImplementedError){ subject.load_sql_schema }
+      assert_raises(NotImplementedError){ subject.dump_sql_schema }
+    end
+
   end
 
-  class LoadSchemaTests < UnitTests
-    desc "given a schema"
+  class LoadAndDumpSchemaTests < UnitTests
     setup do
-      ::FAKE_SCHEMA_LOAD = OpenStruct.new(:count => 0)
+      @orig_stdout = $stdout.dup
+      @captured_stdout = ""
+      $stdout = StringIO.new(@captured_stdout)
+
+      @adapter = SchemaSpyAdapter.new
+    end
+    teardown do
+      $stdout = @orig_stdout
+    end
+
+    should "load a ruby schema using `load_schema`" do
+      assert_false subject.load_ruby_schema_called
+      subject.load_schema
+      assert_true subject.load_ruby_schema_called
+    end
+
+    should "suppress stdout when loading the schema" do
+      subject.load_schema
+      assert_empty @captured_stdout
+    end
+
+    should "dump a ruby schema using `dump_schema`" do
+      assert_false subject.dump_ruby_schema_called
+      subject.dump_schema
+      assert_true subject.dump_ruby_schema_called
+    end
+
+    should "suppress stdout when dumping the schema" do
+      subject.load_schema
+      assert_empty @captured_stdout
+    end
+
+  end
+
+  class LoadRubySchemaTests < UnitTests
+    setup do
       @orig_schema_path = Ardb.config.schema_path
       Ardb.config.schema_path = 'fake_schema.rb'
+
+      @adapter = Ardb::Adapter::Base.new
     end
     teardown do
       Ardb.config.schema_path = @orig_schema_path
     end
 
-    should "load the schema suppressing $stdout" do
-      orig_stdout = $stdout.dup
-      captured_stdout = ""
-      $stdout = StringIO.new(captured_stdout)
-
-      assert_equal 0, FAKE_SCHEMA_LOAD.count
-      subject.load_schema
-      assert_equal 1, FAKE_SCHEMA_LOAD.count
-      subject.load_schema
-      assert_equal 2, FAKE_SCHEMA_LOAD.count
-      assert_empty captured_stdout
-
-      $stdout = orig_stdout
+    should "load a ruby schema file using `load_ruby_schema`" do
+      assert_nil defined?(FAKE_SCHEMA)
+      subject.load_ruby_schema
+      assert_not_nil defined?(FAKE_SCHEMA)
+      assert_equal 1, FAKE_SCHEMA.load_count
+      subject.load_ruby_schema
+      assert_equal 2, FAKE_SCHEMA.load_count
     end
 
+  end
+
+  class SchemaSpyAdapter < Ardb::Adapter::Base
+    attr_reader :load_ruby_schema_called, :dump_ruby_schema_called
+
+    def initialize(*args)
+      super
+      @load_ruby_schema_called = false
+      @dump_ruby_schema_called = false
+    end
+
+    def load_ruby_schema
+      puts "[load_ruby_schema] This should be suppressed!"
+      @load_ruby_schema_called = true
+    end
+
+    def dump_ruby_schema
+      puts "[dump_ruby_schema] This should be suppressed!"
+      @dump_ruby_schema_called = true
+    end
   end
 
 end

--- a/test/unit/runner/migrate_command_tests.rb
+++ b/test/unit/runner/migrate_command_tests.rb
@@ -10,11 +10,10 @@ class Ardb::Runner::MigrateCommand
     end
     subject{ @cmd }
 
-    should have_readers :migrations_path, :schema_file_path, :version, :verbose
+    should have_readers :migrations_path, :version, :verbose
 
-    should "use the config's migrations and schema file paths" do
+    should "use the config's migrations path" do
       assert_equal Ardb.config.migrations_path, subject.migrations_path
-      assert_equal Ardb.config.schema_path, subject.schema_file_path
     end
 
     should "not target a specific version by default" do

--- a/tmp/testdb/fake_schema.rb
+++ b/tmp/testdb/fake_schema.rb
@@ -1,3 +1,5 @@
-puts "This should be suppressed!!"
-
-::FAKE_SCHEMA_LOAD.count += 1
+if !defined?(FAKE_SCHEMA)
+  fake_schema_class = Struct.new(:load_count)
+  FAKE_SCHEMA = fake_schema_class.new(0)
+end
+FAKE_SCHEMA.load_count += 1


### PR DESCRIPTION
This moves the schema dumping logic to the adapter instead of in
the migrate command. This puts it next to the loading schema
logic. It also sets up supporting SQL schema format loading and
dumping, which will have to be done via the adapters. For now,
none of the adapters define sql schema handling and it isn't
used. Eventually, the adapters will check a configuration to see
if they need to use the ruby or sql loading/dumping logic.

@kellyredding - Ready for review.
