### PR TITLE
Add `schema_format` and use when loading/dumping the schema

### DIFF
--- a/lib/ardb.rb
+++ b/lib/ardb.rb
@@ -51,7 +51,8 @@ module Ardb
     option :root_path,       Pathname, :required => true
     option :logger,                    :required => true
     option :migrations_path, RootPath, :default => proc{ "db/migrations" }
-    option :schema_path,     RootPath, :default => proc{ "db/schema.rb" }
+    option :schema_path,     RootPath, :default => proc{ "db/schema" }
+    option :schema_format,   Symbol,   :default => :ruby
 
     def self.db_settings
       db.to_hash.inject({}) do |settings, (k, v)|

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -23,8 +23,8 @@ class Ardb::Config
       assert_equal exp_path, subject.migrations_path
     end
 
-    should "should use `db/schema.rb` as the default schema path" do
-      exp_path = Pathname.new(TESTDB_PATH).join("db/schema.rb").to_s
+    should "should use `db/schema` as the default schema path" do
+      exp_path = Pathname.new(TESTDB_PATH).join("db/schema").to_s
       assert_equal exp_path, subject.schema_path
     end
 


### PR DESCRIPTION
This adds a `schema_format` configuration option and uses it in
the schema loading and dumping logic. This allows specifying if
you want to use ruby or SQL for the schema format. This also
establishes the convention for Ardb that it always dumps the ruby
version of the schema and optionally dumps the SQL schema if the
format is set to SQL. It uses the `schema_format` to determine
if it loads the ruby schema file or the SQL schema file.

This changes the nature of the `schema_path` configuration option.
It no longer points to the a single-file, but provides a template
for the schema logic to build a ruby or SQL schema file path. They
do this by appending a ruby or SQL extension onto the value of the
configuration option.

@kellyredding - Ready for review.
