### PR TITLE
Add PostgreSQL logic for loading/dumping a SQL schema

### DIFF
--- a/ardb.gemspec
+++ b/ardb.gemspec
@@ -18,10 +18,12 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency("assert", ["~> 2.10"])
+  gem.add_development_dependency("assert",       ["~> 2.10"])
+  gem.add_development_dependency("assert-mocha", ["~> 1.1"])
 
   gem.add_dependency('activerecord',  ["~> 3.2"])
   gem.add_dependency('activesupport', ["~> 3.2"])
   gem.add_dependency('ns-options',    ["~> 1.1"])
+  gem.add_dependency('scmd',          ["~> 2.2"])
 
 end

--- a/lib/ardb/adapter/postgresql.rb
+++ b/lib/ardb/adapter/postgresql.rb
@@ -56,6 +56,31 @@ class Ardb::Adapter
       " DROP CONSTRAINT :name"
     end
 
+    def load_sql_schema
+      require 'scmd'
+      cmd_str = "psql -f \"#{self.sql_schema_path}\" #{self.database}"
+      cmd = Scmd.new(cmd_str, env_var_hash).tap(&:run)
+      raise 'Error loading database' unless cmd.success?
+    end
+
+    def dump_sql_schema
+      require 'scmd'
+      cmd_str = "pg_dump -i -s -x -O -f \"#{self.sql_schema_path}\" #{self.database}"
+      cmd = Scmd.new(cmd_str, env_var_hash).tap(&:run)
+      raise 'Error dumping database' unless cmd.success?
+    end
+
+    private
+
+    def env_var_hash
+      @env_var_hash ||= {
+        'PGHOST'     => self.config_settings['host'],
+        'PGPORT'     => self.config_settings['port'],
+        'PGUSER'     => self.config_settings['username'],
+        'PGPASSWORD' => self.config_settings['password']
+      }
+    end
+
   end
 
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -6,6 +6,7 @@ $LOAD_PATH.unshift(File.expand_path("../..", __FILE__))
 
 # require pry for debugging (`binding.pry`)
 require 'pry'
+require 'assert-mocha' if defined?(Assert)
 
 ENV['ARDB_DB_FILE'] = 'tmp/testdb/config/db'
 require 'ardb'


### PR DESCRIPTION
This adds the logic needed to properly load and dump a SQL schema
using the PostgreSQL adapter. This runs the `pgsql` and `pg_dump`
commands to achieve this. This is tested via stubs to make sure
the commands are what is expected. I've loaded this with an
application using PostgreSQL and made sure the commands work as
expected.

@kellyredding - Ready for review.
