### PR TITLE
migrate cli: show any error backtraces

### DIFF
--- a/ardb.gemspec
+++ b/ardb.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency("assert", ["~> 2.14"])
+  gem.add_development_dependency("assert", ["~> 2.15"])
 
   gem.add_dependency('activerecord',  ["~> 3.2"])
   gem.add_dependency('activesupport', ["~> 3.2"])

--- a/lib/ardb/runner/migrate_command.rb
+++ b/lib/ardb/runner/migrate_command.rb
@@ -21,8 +21,9 @@ class Ardb::Runner::MigrateCommand
     rescue Ardb::Runner::CmdError => e
       raise e
     rescue Exception => e
-      $stderr.puts e
       $stderr.puts "error migrating #{Ardb.config.db.database.inspect} database"
+      $stderr.puts e
+      $stderr.puts e.backtrace
       raise Ardb::Runner::CmdFail
     end
   end


### PR DESCRIPTION
This is just a minor cleanup.  I ran into a cryptic migration error
and had no context.  I updated this and reran my migration and the
backtrace confirmed it was coming from activerecord.  This helped
tip me off to a typo in my migration.

Now, I'd prefer activerecord throw a less cryptic error, but that
is a separate issue.  This at least helped me figure things out.

@jcredding ready for review.