### PR TITLE
Update to use the new scmd

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,7 @@ gemspec
 
 gem 'rake'
 gem 'pry',  "~> 0.9.0"
+
+# Lock down gem versions because they require a newer version of ruby
 gem 'i18n', "< 0.7"
 

--- a/ardb.gemspec
+++ b/ardb.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency('activerecord',  ["~> 3.2"])
   gem.add_dependency('activesupport', ["~> 3.2"])
   gem.add_dependency('ns-options',    ["~> 1.1"])
-  gem.add_dependency('scmd',          ["~> 2.3"])
+  gem.add_dependency('scmd',          ["~> 3.0"])
 
 end

--- a/lib/ardb/adapter/postgresql.rb
+++ b/lib/ardb/adapter/postgresql.rb
@@ -59,14 +59,14 @@ class Ardb::Adapter
     def load_sql_schema
       require 'scmd'
       cmd_str = "psql -f \"#{self.sql_schema_path}\" #{self.database}"
-      cmd = Scmd.new(cmd_str, env_var_hash).tap(&:run)
+      cmd = Scmd.new(cmd_str, :env => env_var_hash).tap(&:run)
       raise 'Error loading database' unless cmd.success?
     end
 
     def dump_sql_schema
       require 'scmd'
       cmd_str = "pg_dump -i -s -x -O -f \"#{self.sql_schema_path}\" #{self.database}"
-      cmd = Scmd.new(cmd_str, env_var_hash).tap(&:run)
+      cmd = Scmd.new(cmd_str, :env => env_var_hash).tap(&:run)
       raise 'Error dumping database' unless cmd.success?
     end
 

--- a/test/unit/adapter/postgresql_tests.rb
+++ b/test/unit/adapter/postgresql_tests.rb
@@ -54,7 +54,7 @@ class Ardb::Adapter::Postgresql
     setup do
       cmd_str = "psql -f \"#{@adapter.sql_schema_path}\" #{@adapter.database}"
       @cmd_spy = CmdSpy.new
-      Assert.stub(Scmd, :new).with(cmd_str, @env){ @cmd_spy }
+      Assert.stub(Scmd, :new).with(cmd_str, :env => @env){ @cmd_spy }
     end
 
     should "run a command for loading a SQL schema using `load_sql_schema`" do
@@ -69,7 +69,7 @@ class Ardb::Adapter::Postgresql
       cmd_str = "pg_dump -i -s -x -O -f " \
                 "\"#{@adapter.sql_schema_path}\" #{@adapter.database}"
       @cmd_spy = CmdSpy.new
-      Assert.stub(Scmd, :new).with(cmd_str, @env){ @cmd_spy }
+      Assert.stub(Scmd, :new).with(cmd_str, :env => @env){ @cmd_spy }
     end
 
     should "run a command for dumping a SQL schema using `dump_sql_schema`" do


### PR DESCRIPTION
This updates to use the new scmd which changes how it takes an
env hash. This updates the scmd calls to use the new interface.
No functionality was changed, just update the existing logic to
work with the change to scmds interface.

@kellyredding - Ready for review.