### PR TITLE
Add `Ardb::UseDbDefault` mixin

### DIFF
--- a/lib/ardb/relation_spy.rb
+++ b/lib/ardb/relation_spy.rb
@@ -4,11 +4,13 @@ module Ardb
 
     attr_reader :applied
     attr_accessor :limit_value, :offset_value
+    attr_accessor :pluck_values
     attr_accessor :results
 
     def initialize
       @applied, @results = [], []
       @offset_value, @limit_value = nil, nil
+      @pluck_values = {}
     end
 
     def initialize_copy(copied_from)
@@ -126,6 +128,10 @@ module Ardb
 
     def count
       all.size
+    end
+
+    def pluck(column_name)
+      [@pluck_values[column_name]] * @results.size
     end
 
     class AppliedExpression < Struct.new(:type, :args)

--- a/lib/ardb/use_db_default.rb
+++ b/lib/ardb/use_db_default.rb
@@ -1,0 +1,55 @@
+module Ardb
+
+  module UseDbDefault
+
+    def self.included(klass)
+      klass.class_eval do
+        extend ClassMethods
+        include InstanceMethods
+
+        @ardb_use_db_default_attrs = []
+
+        around_create :ardb_allow_db_to_default_attrs
+
+      end
+    end
+
+    module ClassMethods
+
+      def use_db_default_attrs
+        @ardb_use_db_default_attrs
+      end
+
+      def use_db_default(*attrs)
+        @ardb_use_db_default_attrs += attrs.map(&:to_s)
+        @ardb_use_db_default_attrs.uniq!
+      end
+
+    end
+
+    module InstanceMethods
+
+      private
+
+      def ardb_allow_db_to_default_attrs
+        # this allows the attr to be defaulted by the DB, this keeps
+        # activerecord from adding the attr into the sql `INSERT`, which will
+        # make the DB default its value
+        unchanged_names = self.class.use_db_default_attrs.reject do |name|
+          self.send("#{name}_changed?")
+        end
+        unchanged_names.each{ |name| @attributes.delete(name) }
+        yield
+        # we have to go and fetch the attr value from the DB, otherwise
+        # activerecord doesn't know the value that the DB used
+        scope = self.class.where(:id => self.id)
+        unchanged_names.each do |name|
+          @attributes[name] = scope.pluck(name).first
+        end
+      end
+
+    end
+
+  end
+
+end

--- a/test/unit/relation_spy_tests.rb
+++ b/test/unit/relation_spy_tests.rb
@@ -13,6 +13,7 @@ class Ardb::RelationSpy
     should have_readers :applied
     should have_accessors :results
     should have_accessors :limit_value, :offset_value
+    should have_accessors :pluck_values
     should have_imeths :to_sql, :reset!
     should have_imeths :select
     should have_imeths :from
@@ -24,13 +25,14 @@ class Ardb::RelationSpy
     should have_imeths :limit, :offset
     should have_imeths :merge, :only, :except
     should have_imeths :find, :first, :first!, :last, :last!, :all
-    should have_imeths :count
+    should have_imeths :count, :pluck
 
     should "default it's attributes" do
       assert_equal [], subject.applied
       assert_equal [], subject.results
       assert_nil subject.limit_value
       assert_nil subject.offset_value
+      assert_equal({}, subject.pluck_values)
     end
 
     should "dup its applied and results arrays when copied" do
@@ -466,6 +468,21 @@ class Ardb::RelationSpy
       assert_equal subject.all.size, subject.count
       subject.limit 2
       assert_equal subject.all.size, subject.count
+    end
+
+  end
+
+  class PluckTests < WithResultsTests
+    desc "pluck"
+    setup do
+      @column_name  = Factory.string
+      @column_value = Factory.string
+      @relation_spy.pluck_values[@column_name] = @column_value
+    end
+
+    should "return a pluck value for every result" do
+      exp = [@column_value] * @results.size
+      assert_equal exp, @relation_spy.pluck(@column_name)
     end
 
   end

--- a/test/unit/use_db_default_tests.rb
+++ b/test/unit/use_db_default_tests.rb
@@ -1,0 +1,155 @@
+require 'assert'
+require 'ardb/use_db_default'
+
+require 'ardb/record_spy'
+
+module Ardb::UseDbDefault
+
+  class UnitTests < Assert::Context
+    desc "Ardb::UseDbDefault"
+    setup do
+      @record_class = Class.new do
+        include UseDbDefaultRecordSpy
+        include Ardb::UseDbDefault
+      end
+    end
+    subject{ @record_class }
+
+    should have_imeths :use_db_default, :use_db_default_attrs
+
+    should "know its use db default attrs" do
+      assert_equal [], subject.use_db_default_attrs
+    end
+
+    should "add use db default attributes using `use_db_default`" do
+      attr_name = Factory.string
+      subject.use_db_default(attr_name)
+      assert_includes attr_name, subject.use_db_default_attrs
+
+      attr_names = [Factory.string, Factory.string.to_sym]
+      subject.use_db_default(*attr_names)
+      attr_names.each do |attr_name|
+        assert_includes attr_name.to_s, subject.use_db_default_attrs
+      end
+    end
+
+    should "not add duplicate attributes using `use_db_default`" do
+      attr_name = Factory.string
+      subject.use_db_default(attr_name)
+      assert_equal [attr_name], subject.use_db_default_attrs
+
+      subject.use_db_default(attr_name)
+      assert_equal [attr_name], subject.use_db_default_attrs
+
+      more_attr_names = [attr_name, Factory.string]
+      subject.use_db_default(*more_attr_names)
+      exp = ([attr_name] + more_attr_names).uniq
+      assert_equal exp, subject.use_db_default_attrs
+    end
+
+    should "add an around create callback" do
+      callback = subject.callbacks.first
+      assert_equal :around_create, callback.type
+      exp = [:ardb_allow_db_to_default_attrs]
+      assert_equal exp, callback.args
+    end
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @attr_names = Factory.integer(3).times.map{ Factory.string }
+      @record_class.use_db_default(*@attr_names)
+
+      @record = @record_class.new
+
+      # simulate activerecords `@attributes` hash
+      @original_attrs = @attr_names.inject({}) do |h, n|
+        h.merge!(n => [nil, Factory.string, Factory.integer].choice)
+      end
+      @original_attrs.merge!(Factory.string => Factory.string)
+      @record.attributes = @original_attrs.dup
+
+      # randomly pick a use-db-default attribute to be changed
+      @record.changed_use_db_default_attrs = [@attr_names.choice]
+      @unchanged_attr_names = @attr_names - @record.changed_use_db_default_attrs
+
+      # we should always get the record we just inserted back
+      @record_class.relation_spy.results = [@record]
+      # add pluck values into the relation spy
+      @record_class.relation_spy.pluck_values = @attr_names.inject({}) do |h, n|
+        h.merge!(n => Factory.string)
+      end
+    end
+    subject{ @record }
+
+    should "remove use-db-default attributes before being created" do
+      # around create callbacks yield to create the record so we have to pass a
+      # block, this will allow us to see what was done to the attributes hash
+      # when it was created (yielded)
+      attrs_before_yield = nil
+      subject.instance_eval do
+        ardb_allow_db_to_default_attrs{ attrs_before_yield = self.attributes.dup }
+      end
+
+      assert_instance_of Hash, attrs_before_yield
+      @unchanged_attr_names.each do |name|
+        assert_false attrs_before_yield.key?(name)
+      end
+
+      # the non use-db-default attrs and changed use-db-default attrs hash
+      # values should have their original values when yielded
+      (@original_attrs.keys - @unchanged_attr_names).each do |name|
+        assert_equal @original_attrs[name], attrs_before_yield[name]
+      end
+    end
+
+    should "set use-db-default values after its created" do
+      # around create callbacks yield to create the record so we have to pass a
+      # block, this simulates creating the record by setting the id
+      subject.instance_eval do
+        ardb_allow_db_to_default_attrs{ self.id = Factory.integer }
+      end
+
+      applied_expr = @record_class.relation_spy.applied.first
+      assert_equal :where, applied_expr.type
+      assert_equal [{ :id => subject.id }], applied_expr.args
+
+      @unchanged_attr_names.each do |name|
+        exp = @record_class.relation_spy.pluck_values[name]
+        assert_equal exp, subject.attributes[name]
+      end
+
+      # the non use-db-default attrs and changed use-db-default attrs hash
+      # values should still have their original values
+      (@original_attrs.keys - @unchanged_attr_names).each do |name|
+        assert_equal @original_attrs[name], subject.attributes[name]
+      end
+    end
+
+  end
+
+  module UseDbDefaultRecordSpy
+    def self.included(klass)
+      klass.class_eval{ include Ardb::RecordSpy }
+    end
+
+    attr_accessor :id
+    attr_accessor :attributes, :changed_use_db_default_attrs
+
+    def use_db_default_attr_changed?(attr_name)
+      self.changed_use_db_default_attrs.include?(attr_name)
+    end
+
+    def method_missing(method, *args, &block)
+      match_data = method.to_s.match(/(\w+)_changed\?/)
+      if match_data && match_data[1]
+        self.use_db_default_attr_changed?(match_data[1])
+      else
+        super
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
This adds a use db default mixin which will allow columns to be
defaulted by the db. This is specifically needed to make use of
defaulting a non primary key column using a postgres sequence.

Firstly, activerecord doesn't really use defaults that are
configured on columns. For simple defaults, like a literal value,
activerecord does the actual defaulting when you instantiate an
instance of a record. Otherwise all columns have a `nil` value.
When these are saved, activerecord sends values for all columns
which keeps the DB from defaulting them.

This allows the DB to default values by keeping activerecord from
sending them when it runs a sql `INSERT`. To do this, the mixin
adds an around create callback that will check if a column has
been changed. If it hasn't then we remove it from the the
attributes hash. If this is done, activerecord won't send it in
its sql `INSERT`.

After the record has been created though, it still won't have
values for DB defaulted attributes. Activerecord doesn't reload
all values by default. To fix this, for the attributes that we let
the DB default, we `pluck` their values from the DB. This ensures
we have them after the model is created.

As part of this effort, this also extends the relation spy to have
`pluck` and allow providing values for it to return.

@kellyredding - Ready for review.