### PR TITLE
Fix has slug when the source is already a valid slug

### DIFF
--- a/lib/ardb/has_slug.rb
+++ b/lib/ardb/has_slug.rb
@@ -52,18 +52,20 @@ module Ardb
       end
 
       def ardb_has_slug_generate_slug
-        slug_attr_value = self.send(self.class.ardb_has_slug_config[:attribute])
-        if !slug_attr_value || slug_attr_value.to_s.empty?
-          slug_attr_value = self.instance_eval(&self.class.ardb_has_slug_config[:source_proc])
+        attr_name = self.class.ardb_has_slug_config[:attribute]
+        slug_source = if !self.send(attr_name) || self.send(attr_name).to_s.empty?
+          self.instance_eval(&self.class.ardb_has_slug_config[:source_proc])
+        else
+          self.send(attr_name)
         end
 
-        generated_slug = Slug.new(slug_attr_value, {
+        generated_slug = Slug.new(slug_source, {
           :preprocessor      => self.class.ardb_has_slug_config[:preprocessor_proc],
           :allow_underscores => self.class.ardb_has_slug_config[:allow_underscores]
         })
-        return if slug_attr_value == generated_slug
-        self.send("#{self.class.ardb_has_slug_config[:attribute]}=", generated_slug)
-        self.update_column(self.class.ardb_has_slug_config[:attribute], generated_slug)
+        return if self.send(attr_name) == generated_slug
+        self.send("#{attr_name}=", generated_slug)
+        self.update_column(attr_name, generated_slug)
       end
 
     end

--- a/test/unit/has_slug_tests.rb
+++ b/test/unit/has_slug_tests.rb
@@ -150,6 +150,23 @@ module Ardb::HasSlug
       assert_equal exp,             subject.slug_db_column_value
     end
 
+    should "slug its source even if its already a valid slug using `ardb_has_slug_generate_slug`" do
+      slug_source = Factory.slug
+      @record.send("#{@source_attribute}=", slug_source)
+      # ensure the preprocessor doesn't change our source
+      Assert.stub(slug_source, @preprocessor){ slug_source }
+
+      subject.instance_eval{ ardb_has_slug_generate_slug }
+
+      exp = Slug.new(slug_source, {
+        :preprocessor      => @preprocessor.to_proc,
+        :allow_underscores => @allow_underscores
+      })
+      assert_equal exp,             subject.send(@slug_attribute)
+      assert_equal @slug_attribute, subject.slug_db_column_name
+      assert_equal exp,             subject.slug_db_column_value
+    end
+
     should "not set its slug if it hasn't changed using `ardb_has_slug_generate_slug`" do
       generated_slug = Slug.new(@source_value, {
         :preprocessor      => @preprocessor.to_proc,
@@ -168,7 +185,7 @@ module Ardb::HasSlug
     desc "Slug"
     subject{ Slug }
 
-    NON_WORD_CHARS = ((' '..'/').to_a + (':'..'@').to_a + ('['+'`').to_a +
+    NON_WORD_CHARS = ((' '..'/').to_a + (':'..'@').to_a + ('['..'`').to_a +
                      ('{'..'~').to_a - ['-', '_']).freeze
 
     should have_imeths :new


### PR DESCRIPTION
This fixes a bug with `HasSlug` that caused it to not set its slug
when the source was already a valid slug. This was missed when
initially adding the `HasSlug` mixin.

The tests always assumed slugging the source produced something
different than the source's original value. The problem was that
the source value was being used to see if it matched the generated
slug instead of the slugs attributes current value. In the tests,
the source is setup so it will never match the generated slug
because we are testing other behavior like using the preprocessor
and allowing underscores. This adds a test that makes the source
and the generated slug match but the slug attribute be different
and ensures it sets the slug correctly.

This also fixes a minor bug with the slug tests using non-word
chars. I meant to use the ASCII range between '[' and '`' but
accidentally concatenated them. This caused the tests to fail
because they expected to be using single char seperators.

@kellyredding - Ready for review. I had tested this in the console and a few tests but not where the source was a value that matched a generated slug. Our big app had lots of errors because of MR record factories default string value.