### PR TITLE
Move the logic for Migrating a DB into Adapter::Base

### DIFF
--- a/lib/ardb/adapter_spy.rb
+++ b/lib/ardb/adapter_spy.rb
@@ -19,6 +19,7 @@ module Ardb
 
       attr_accessor :drop_tables_called_count, :load_schema_called_count
       attr_accessor :drop_db_called_count, :create_db_called_count
+      attr_accessor :migrate_db_called_count
 
       def drop_tables_called_count
         @drop_tables_called_count ||= 0
@@ -50,6 +51,14 @@ module Ardb
 
       def create_db(*args, &block)
         self.create_db_called_count += 1
+      end
+
+      def migrate_db_called_count
+        @migrate_db_called_count ||= 0
+      end
+
+      def migrate_db(*args, &block)
+        self.migrate_db_called_count += 1
       end
 
     end

--- a/lib/ardb/runner/migrate_command.rb
+++ b/lib/ardb/runner/migrate_command.rb
@@ -1,23 +1,18 @@
 require 'fileutils'
 require 'active_record'
 require 'ardb/runner'
-require 'ardb/migration_helpers'
 
 class Ardb::Runner::MigrateCommand
 
-  attr_reader :migrations_path, :version, :verbose
-
   def initialize
     @adapter = Ardb::Adapter.send(Ardb.config.db.adapter)
-    @migrations_path = Ardb.config.migrations_path
-    @version = ENV["VERSION"] ? ENV["VERSION"].to_i : nil
-    @verbose = ENV["VERBOSE"] ? ENV["VERBOSE"] == "true" : true
   end
 
   def run
     begin
       Ardb.init
-      migrate_the_db
+      @adapter.migrate_db
+      @adapter.dump_schema
     rescue Ardb::Runner::CmdError => e
       raise e
     rescue Exception => e
@@ -26,22 +21,6 @@ class Ardb::Runner::MigrateCommand
       $stderr.puts e.backtrace
       raise Ardb::Runner::CmdFail
     end
-  end
-
-  def migrate_the_db
-    if defined?(ActiveRecord::Migration::CommandRecorder)
-      ActiveRecord::Migration::CommandRecorder.class_eval do
-        include Ardb::MigrationHelpers::RecorderMixin
-      end
-    end
-
-    ActiveRecord::Migrator.migrations_path = @migrations_path
-    ActiveRecord::Migration.verbose = @verbose
-    ActiveRecord::Migrator.migrate(@migrations_path, @version) do |migration|
-      ENV["SCOPE"].blank? || (ENV["SCOPE"] == migration.scope)
-    end
-
-    @adapter.dump_schema
   end
 
 end

--- a/lib/ardb/test_helpers.rb
+++ b/lib/ardb/test_helpers.rb
@@ -16,9 +16,42 @@ module Ardb::TestHelpers
     Ardb.adapter.load_schema
   end
 
-  def reset_db!
-    Ardb.adapter.drop_db
+  def create_db!
     Ardb.adapter.create_db
+  end
+
+  def create_db
+    @create_db ||= begin
+      self.create_db!
+      true
+    end
+  end
+
+  def drop_db!
+    Ardb.adapter.drop_db
+  end
+
+  def drop_db
+    @drop_db ||= begin
+      self.drop_db!
+      true
+    end
+  end
+
+  def migrate_db!
+    Ardb.adapter.migrate_db
+  end
+
+  def migrate_db
+    @migrate_db ||= begin
+      self.migrate_db!
+      true
+    end
+  end
+
+  def reset_db!
+    self.drop_db!
+    self.create_db!
     self.load_schema
   end
 

--- a/test/unit/runner/migrate_command_tests.rb
+++ b/test/unit/runner/migrate_command_tests.rb
@@ -10,51 +10,7 @@ class Ardb::Runner::MigrateCommand
     end
     subject{ @cmd }
 
-    should have_readers :migrations_path, :version, :verbose
-
-    should "use the config's migrations path" do
-      assert_equal Ardb.config.migrations_path, subject.migrations_path
-    end
-
-    should "not target a specific version by default" do
-      assert_nil subject.version
-    end
-
-    should "be verbose by default" do
-      assert subject.verbose
-    end
-
-  end
-
-  class VersionTests < UnitTests
-    desc "with a version ENV setting"
-    setup do
-      ENV["VERSION"] = '12345'
-      @cmd = Ardb::Runner::MigrateCommand.new
-    end
-    teardown do
-      ENV["VERSION"] = nil
-    end
-
-    should "should target the given version" do
-      assert_equal 12345, subject.version
-    end
-
-  end
-
-  class VerboseTests < UnitTests
-    desc "with a verbose ENV setting"
-    setup do
-      ENV["VERBOSE"] = 'no'
-      @cmd = Ardb::Runner::MigrateCommand.new
-    end
-    teardown do
-      ENV["VERBOSE"] = nil
-    end
-
-    should "turn off verbose mode if not set to 'true'" do
-      assert_not subject.verbose
-    end
+    should have_imeths :run
 
   end
 

--- a/test/unit/test_helpers_tests.rb
+++ b/test/unit/test_helpers_tests.rb
@@ -1,4 +1,5 @@
 require 'assert'
+require 'ardb/adapter_spy'
 require 'ardb/test_helpers'
 
 module Ardb::TestHelpers
@@ -7,7 +8,9 @@ module Ardb::TestHelpers
     desc "Ardb test helpers"
     subject{ Ardb::TestHelpers }
 
-    should have_imeths :drop_tables, :load_schema, :reset_db, :reset_db!
+    should have_imeths :drop_tables, :load_schema
+    should have_imeths :create_db!, :create_db, :drop_db!, :drop_db
+    should have_imeths :migrate_db!, :migrate_db, :reset_db, :reset_db!
 
   end
 
@@ -41,6 +44,69 @@ module Ardb::TestHelpers
       assert_equal 0, @adapter_spy.load_schema_called_count
       subject.load_schema
       assert_equal 1, @adapter_spy.load_schema_called_count
+    end
+
+  end
+
+  class CreateDbTests < UsageTests
+    desc "create db method"
+
+    should "tell the adapter to create the db only once" do
+      assert_equal 0, @adapter_spy.create_db_called_count
+      subject.create_db
+      assert_equal 1, @adapter_spy.create_db_called_count
+      subject.create_db
+      assert_equal 1, @adapter_spy.create_db_called_count
+    end
+
+    should "force the adapter to create a db" do
+      assert_equal 0, @adapter_spy.create_db_called_count
+      subject.create_db!
+      assert_equal 1, @adapter_spy.create_db_called_count
+      subject.create_db!
+      assert_equal 2, @adapter_spy.create_db_called_count
+    end
+
+  end
+
+  class DropDbTests < UsageTests
+    desc "drop db methods"
+
+    should "tell the adapter to drop the db only once" do
+      assert_equal 0, @adapter_spy.drop_db_called_count
+      subject.drop_db
+      assert_equal 1, @adapter_spy.drop_db_called_count
+      subject.drop_db
+      assert_equal 1, @adapter_spy.drop_db_called_count
+    end
+
+    should "force the adapter to drop a db" do
+      assert_equal 0, @adapter_spy.drop_db_called_count
+      subject.drop_db!
+      assert_equal 1, @adapter_spy.drop_db_called_count
+      subject.drop_db!
+      assert_equal 2, @adapter_spy.drop_db_called_count
+    end
+
+  end
+
+  class MigrateDbTests < UsageTests
+    desc "migrate db methods"
+
+    should "tell the adapter to migrate the db only once" do
+      assert_equal 0, @adapter_spy.migrate_db_called_count
+      subject.migrate_db
+      assert_equal 1, @adapter_spy.migrate_db_called_count
+      subject.migrate_db
+      assert_equal 1, @adapter_spy.migrate_db_called_count
+    end
+
+    should "force the adapter to migrate a db" do
+      assert_equal 0, @adapter_spy.migrate_db_called_count
+      subject.migrate_db!
+      assert_equal 1, @adapter_spy.migrate_db_called_count
+      subject.migrate_db!
+      assert_equal 2, @adapter_spy.migrate_db_called_count
     end
 
   end


### PR DESCRIPTION
This moves the logic for migrating a DB into Adapter::Base so that
it may be called independently of the command line.  Though the migration
doesn't directly use the Adapter, it is a common place for it to live
so that all Adapters can migrate the db in a similar manner as they
create or drop the db.

This also updates the TestHelpers so that apps do not need to directly
interact with the Adapter to drop, create, migrate, or reset the db.
This used the existing pattern of only running a DB command once per
call, but still allowing users to force the call using the bang version
of the method.