### PR TITLE
Update Adapter based Commands to use AdapterSpy in testing

### DIFF
--- a/lib/ardb/adapter_spy.rb
+++ b/lib/ardb/adapter_spy.rb
@@ -17,7 +17,8 @@ module Ardb
 
     module InstanceMethods
 
-      attr_accessor :drop_tables_called_count, :load_schema_called_count
+      attr_accessor :drop_tables_called_count
+      attr_accessor :dump_schema_called_count, :load_schema_called_count
       attr_accessor :drop_db_called_count, :create_db_called_count
       attr_accessor :migrate_db_called_count
 
@@ -25,12 +26,32 @@ module Ardb
         @drop_tables_called_count ||= 0
       end
 
+      def drop_tables_called?
+        self.drop_tables_called_count > 0
+      end
+
       def drop_tables(*args, &block)
         self.drop_tables_called_count += 1
       end
 
+      def dump_schema_called_count
+        @dump_schema_called_count ||= 0
+      end
+
+      def dump_schema_called?
+        self.dump_schema_called_count > 0
+      end
+
+      def dump_schema(*args, &block)
+        self.dump_schema_called_count += 1
+      end
+
       def load_schema_called_count
         @load_schema_called_count ||= 0
+      end
+
+      def load_schema_called?
+        self.load_schema_called_count > 0
       end
 
       def load_schema(*args, &block)
@@ -41,6 +62,10 @@ module Ardb
         @drop_db_called_count ||= 0
       end
 
+      def drop_db_called?
+        self.drop_db_called_count > 0
+      end
+
       def drop_db(*args, &block)
         self.drop_db_called_count += 1
       end
@@ -49,12 +74,20 @@ module Ardb
         @create_db_called_count ||= 0
       end
 
+      def create_db_called?
+        self.create_db_called_count > 0
+      end
+
       def create_db(*args, &block)
         self.create_db_called_count += 1
       end
 
       def migrate_db_called_count
         @migrate_db_called_count ||= 0
+      end
+
+      def migrate_db_called?
+        self.migrate_db_called_count > 0
       end
 
       def migrate_db(*args, &block)

--- a/lib/ardb/runner/create_command.rb
+++ b/lib/ardb/runner/create_command.rb
@@ -3,19 +3,21 @@ require 'ardb/runner'
 
 class Ardb::Runner::CreateCommand
 
-  def initialize
+  def initialize(out_io = nil, err_io = nil)
+    @out_io = out_io || $stdout
+    @err_io = err_io || $stderr
     @adapter = Ardb::Adapter.send(Ardb.config.db.adapter)
   end
 
   def run
     begin
       @adapter.create_db
-      $stdout.puts "created #{Ardb.config.db.adapter} db `#{Ardb.config.db.database}`"
+      @out_io.puts "created #{Ardb.config.db.adapter} db `#{Ardb.config.db.database}`"
     rescue Ardb::Runner::CmdError => e
       raise e
-    rescue Exception => e
-      $stderr.puts e
-      $stderr.puts "error creating #{Ardb.config.db.database.inspect} database"
+    rescue StandardError => e
+      @err_io.puts e
+      @err_io.puts "error creating #{Ardb.config.db.database.inspect} database"
       raise Ardb::Runner::CmdFail
     end
   end

--- a/lib/ardb/runner/drop_command.rb
+++ b/lib/ardb/runner/drop_command.rb
@@ -3,19 +3,21 @@ require 'ardb/runner'
 
 class Ardb::Runner::DropCommand
 
-  def initialize
+  def initialize(out_io = nil, err_io = nil)
+    @out_io = out_io || $stdout
+    @err_io = err_io || $stderr
     @adapter = Ardb::Adapter.send(Ardb.config.db.adapter)
   end
 
   def run
     begin
       @adapter.drop_db
-      $stdout.puts "dropped #{Ardb.config.db.adapter} db `#{Ardb.config.db.database}`"
+      @out_io.puts "dropped #{Ardb.config.db.adapter} db `#{Ardb.config.db.database}`"
     rescue Ardb::Runner::CmdError => e
       raise e
-    rescue Exception => e
-      $stderr.puts e
-      $stderr.puts "error dropping #{Ardb.config.db.database.inspect} database"
+    rescue StandardError => e
+      @err_io.puts e
+      @err_io.puts "error dropping #{Ardb.config.db.database.inspect} database"
       raise Ardb::Runner::CmdFail
     end
   end

--- a/lib/ardb/runner/migrate_command.rb
+++ b/lib/ardb/runner/migrate_command.rb
@@ -4,7 +4,9 @@ require 'ardb/runner'
 
 class Ardb::Runner::MigrateCommand
 
-  def initialize
+  def initialize(out_io = nil, err_io = nil)
+    @out_io = out_io || $stdout
+    @err_io = err_io || $stderr
     @adapter = Ardb::Adapter.send(Ardb.config.db.adapter)
   end
 
@@ -15,10 +17,10 @@ class Ardb::Runner::MigrateCommand
       @adapter.dump_schema
     rescue Ardb::Runner::CmdError => e
       raise e
-    rescue Exception => e
-      $stderr.puts "error migrating #{Ardb.config.db.database.inspect} database"
-      $stderr.puts e
-      $stderr.puts e.backtrace
+    rescue StandardError => e
+      @err_io.puts "error migrating #{Ardb.config.db.database.inspect} database"
+      @err_io.puts e
+      @err_io.puts e.backtrace
       raise Ardb::Runner::CmdFail
     end
   end

--- a/test/unit/adapter_spy_tests.rb
+++ b/test/unit/adapter_spy_tests.rb
@@ -14,9 +14,16 @@ module Ardb::AdapterSpy
     end
     subject{ @adapter }
 
-    should have_accessors :drop_tables_called_count, :load_schema_called_count
+    should have_accessors :drop_tables_called_count
+    should have_accessors :dump_schema_called_count, :load_schema_called_count
     should have_accessors :drop_db_called_count, :create_db_called_count
-    should have_imeths :drop_tables, :load_schema, :drop_db, :create_db
+    should have_accessors :migrate_db_called_count
+    should have_imeths :drop_tables_called?, :drop_tables
+    should have_imeths :dump_schema_called?, :dump_schema
+    should have_imeths :load_schema_called?, :load_schema
+    should have_imeths :drop_db_called?, :drop_db
+    should have_imeths :create_db_called?, :create_db
+    should have_imeths :migrate_db_called?, :migrate_db
 
     should "included the record spy instance methods" do
       assert_includes Ardb::AdapterSpy::InstanceMethods, subject.class
@@ -24,23 +31,43 @@ module Ardb::AdapterSpy
 
     should "default all call counts to zero" do
       assert_equal 0, subject.drop_tables_called_count
+      assert_equal 0, subject.dump_schema_called_count
       assert_equal 0, subject.load_schema_called_count
       assert_equal 0, subject.drop_db_called_count
       assert_equal 0, subject.create_db_called_count
+      assert_equal 0, subject.migrate_db_called_count
     end
 
-    should "add a call count when each method is called" do
+    should "know if and how many times a method is called" do
+      assert_equal false, subject.drop_tables_called?
       subject.drop_tables
       assert_equal 1, subject.drop_tables_called_count
+      assert_equal true, subject.drop_tables_called?
 
+      assert_equal false, subject.dump_schema_called?
+      subject.dump_schema
+      assert_equal 1, subject.dump_schema_called_count
+      assert_equal true, subject.dump_schema_called?
+
+      assert_equal false, subject.load_schema_called?
       subject.load_schema
       assert_equal 1, subject.load_schema_called_count
+      assert_equal true, subject.load_schema_called?
 
+      assert_equal false, subject.drop_db_called?
       subject.drop_db
       assert_equal 1, subject.drop_db_called_count
+      assert_equal true, subject.drop_db_called?
 
+      assert_equal false, subject.create_db_called?
       subject.create_db
       assert_equal 1, subject.create_db_called_count
+      assert_equal true, subject.create_db_called?
+
+      assert_equal false, subject.migrate_db_called?
+      subject.migrate_db
+      assert_equal 1, subject.migrate_db_called_count
+      assert_equal true, subject.migrate_db_called?
     end
 
   end

--- a/test/unit/runner/connect_command_tests.rb
+++ b/test/unit/runner/connect_command_tests.rb
@@ -1,7 +1,7 @@
 require 'assert'
 require 'ardb/runner/connect_command'
 
-class Ardb::Runner::CreateCommand
+class Ardb::Runner::ConnectCommand
 
   class UnitTests < Assert::Context
     desc "Ardb::Runner::ConnectCommand"

--- a/test/unit/runner/create_command_tests.rb
+++ b/test/unit/runner/create_command_tests.rb
@@ -1,4 +1,5 @@
 require 'assert'
+require 'ardb/adapter_spy'
 require 'ardb/runner/create_command'
 
 class Ardb::Runner::CreateCommand
@@ -6,11 +7,60 @@ class Ardb::Runner::CreateCommand
   class UnitTests < Assert::Context
     desc "Ardb::Runner::CreateCommand"
     setup do
-      @cmd = Ardb::Runner::CreateCommand.new
+      @command_class = Ardb::Runner::CreateCommand
     end
-    subject{ @cmd }
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @adapter_spy = Class.new{ include Ardb::AdapterSpy }.new
+      Assert.stub(Ardb::Adapter, Ardb.config.db.adapter.to_sym){ @adapter_spy }
+
+      # provide an output and error IO to avoid using $stdout/$stderr in tests
+      out_io = err_io = StringIO.new
+      @command = @command_class.new(out_io, err_io)
+    end
+    subject{ @command }
 
     should have_imeths :run
+
+  end
+
+  class RunTests < InitTests
+    desc "and run"
+    setup do
+      @command.run
+    end
+
+    should "create the db via the adapter" do
+      assert_equal true, @adapter_spy.create_db_called?
+    end
+
+  end
+
+  class RunWithCmdErrorTests < InitTests
+    desc "and run with command errors"
+    setup do
+      Assert.stub(@adapter_spy, :create_db){ raise Ardb::Runner::CmdError.new }
+    end
+
+    should "not handle the error" do
+      assert_raises(Ardb::Runner::CmdError){ subject.run }
+    end
+
+  end
+
+  class RunWithUnspecifiedErrorTests < InitTests
+    desc "and run with a standard error"
+    setup do
+      Assert.stub(@adapter_spy, :create_db){ raise StandardError.new }
+    end
+
+    should "raise a CmdFail error" do
+      assert_raises(Ardb::Runner::CmdFail){ subject.run }
+    end
 
   end
 

--- a/test/unit/runner/drop_command_tests.rb
+++ b/test/unit/runner/drop_command_tests.rb
@@ -1,4 +1,5 @@
 require 'assert'
+require 'ardb/adapter_spy'
 require 'ardb/runner/drop_command'
 
 class Ardb::Runner::DropCommand
@@ -6,12 +7,62 @@ class Ardb::Runner::DropCommand
   class UnitTests < Assert::Context
     desc "Ardb::Runner::DropCommand"
     setup do
-      @cmd = Ardb::Runner::DropCommand.new
+      @command_class = Ardb::Runner::DropCommand
     end
-    subject{ @cmd }
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @adapter_spy = Class.new{ include Ardb::AdapterSpy }.new
+      Assert.stub(Ardb::Adapter, Ardb.config.db.adapter.to_sym){ @adapter_spy }
+
+      # provide an output and error IO to avoid using $stdout/$stderr in tests
+      out_io = err_io = StringIO.new
+      @command = @command_class.new(out_io, err_io)
+    end
+    subject{ @command }
 
     should have_imeths :run
 
   end
 
+  class RunTests < InitTests
+    desc "and run"
+    setup do
+      @command.run
+    end
+
+    should "drop the db via the adapter" do
+      assert_equal true, @adapter_spy.drop_db_called?
+    end
+
+  end
+
+  class RunWithCmdErrorTests < InitTests
+    desc "and run with command errors"
+    setup do
+      Assert.stub(@adapter_spy, :drop_db){ raise Ardb::Runner::CmdError.new }
+    end
+
+    should "not handle the error" do
+      assert_raises(Ardb::Runner::CmdError){ subject.run }
+    end
+
+  end
+
+  class RunWithUnspecifiedErrorTests < InitTests
+    desc "and run with a standard error"
+    setup do
+      Assert.stub(@adapter_spy, :drop_db){ raise StandardError.new }
+    end
+
+    should "raise a CmdFail error" do
+      assert_raises(Ardb::Runner::CmdFail){ subject.run }
+    end
+
+  end
+
 end
+

--- a/test/unit/runner/migrate_command_tests.rb
+++ b/test/unit/runner/migrate_command_tests.rb
@@ -1,4 +1,5 @@
 require 'assert'
+require 'ardb/adapter_spy'
 require 'ardb/runner/migrate_command'
 
 class Ardb::Runner::MigrateCommand
@@ -6,11 +7,65 @@ class Ardb::Runner::MigrateCommand
   class UnitTests < Assert::Context
     desc "Ardb::Runner::MigrateCommand"
     setup do
-      @cmd = Ardb::Runner::MigrateCommand.new
+      @command_class = Ardb::Runner::MigrateCommand
     end
-    subject{ @cmd }
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @adapter_spy = Class.new{ include Ardb::AdapterSpy }.new
+      Assert.stub(Ardb::Adapter, Ardb.config.db.adapter.to_sym){ @adapter_spy }
+
+      @ardb_init_called = false
+      Assert.stub(Ardb, :init){ @ardb_init_called = true }
+
+      # provide an output and error IO to avoid using $stdout/$stderr in tests
+      out_io = err_io = StringIO.new
+      @command = @command_class.new(out_io, err_io)
+    end
+    subject{ @command }
 
     should have_imeths :run
+
+  end
+
+  class RunTests < InitTests
+    desc "and run"
+    setup do
+      @command.run
+    end
+
+    should "initialize Ardb, migrate the db and dump schema via the adapter" do
+      assert_equal true, @ardb_init_called
+      assert_equal true, @adapter_spy.migrate_db_called?
+      assert_equal true, @adapter_spy.dump_schema_called?
+    end
+
+  end
+
+  class RunWithCmdErrorTests < InitTests
+    desc "and run with command errors"
+    setup do
+      Assert.stub(@adapter_spy, :migrate_db){ raise Ardb::Runner::CmdError.new }
+    end
+
+    should "not handle the error" do
+      assert_raises(Ardb::Runner::CmdError){ subject.run }
+    end
+
+  end
+
+  class RunWithUnspecifiedErrorTests < InitTests
+    desc "and run with a standard error"
+    setup do
+      Assert.stub(@adapter_spy, :migrate_db){ raise StandardError.new }
+    end
+
+    should "raise a CmdFail error" do
+      assert_raises(Ardb::Runner::CmdFail){ subject.run }
+    end
 
   end
 


### PR DESCRIPTION
This updates the testing of Ardb Commands that use the Adapter to
use the Ardb::AdapterSpy.  This allows the testing of `run` behavior.
This also updates those commands to optionally accept an output and
error IO, and use those IO's rather than `$stdout` and `$stderr`.  This
was done so that in the test environment we can avoid writing to the
console when running these Commands.

This also updates the AdapterSpy to include methods for spying the
`dump_schema` command as well as helpers to determine if a command
was run.