### PR TITLE
Add `DefaultOrderBy` mixin

### DIFF
--- a/ardb.gemspec
+++ b/ardb.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency('activerecord',  ["~> 3.2"])
   gem.add_dependency('activesupport', ["~> 3.2"])
+  gem.add_dependency('much-plugin',   ["~> 0.1"])
   gem.add_dependency('ns-options',    ["~> 1.1"])
   gem.add_dependency('scmd',          ["~> 3.0"])
 

--- a/lib/ardb/default_order_by.rb
+++ b/lib/ardb/default_order_by.rb
@@ -1,0 +1,59 @@
+require 'much-plugin'
+
+module Ardb
+
+  module DefaultOrderBy
+    include MuchPlugin
+
+    DEFAULT_ATTRIBUTE  = :order_by
+    DEFAULT_SCOPE_PROC = proc{ self.class.scoped }
+
+    plugin_included do
+      extend ClassMethods
+      include InstanceMethods
+
+      @ardb_default_order_by_config = {}
+
+    end
+
+    module ClassMethods
+
+      def default_order_by(options = nil)
+        options ||= {}
+
+        @ardb_default_order_by_config.merge!({
+          :attribute  => options[:attribute] || DEFAULT_ATTRIBUTE,
+          :scope_proc => options[:scope]     || DEFAULT_SCOPE_PROC
+        })
+
+        before_validation :ardb_default_order_by, :on => :create
+      end
+
+      def ardb_default_order_by_config
+        @ardb_default_order_by_config
+      end
+
+    end
+
+    module InstanceMethods
+
+      private
+
+      def reset_order_by
+        attr_name  = self.class.ardb_default_order_by_config[:attribute]
+        scope_proc = self.class.ardb_default_order_by_config[:scope_proc]
+
+        current_max = self.instance_eval(&scope_proc).maximum(attr_name) || 0
+        self.send("#{attr_name}=", current_max + 1)
+      end
+
+      def ardb_default_order_by
+        attr_name = self.class.ardb_default_order_by_config[:attribute]
+        reset_order_by if self.send(attr_name).to_s.empty?
+        true
+      end
+
+    end
+
+  end
+end

--- a/lib/ardb/relation_spy.rb
+++ b/lib/ardb/relation_spy.rb
@@ -4,13 +4,16 @@ module Ardb
 
     attr_reader :applied
     attr_accessor :limit_value, :offset_value
-    attr_accessor :pluck_values
+    attr_accessor :pluck_values, :maximum_values, :minimum_values
     attr_accessor :results
 
     def initialize
       @applied, @results = [], []
       @offset_value, @limit_value = nil, nil
-      @pluck_values = {}
+
+      @pluck_values   = {}
+      @maximum_values = {}
+      @minimum_values = {}
     end
 
     def initialize_copy(copied_from)
@@ -132,6 +135,14 @@ module Ardb
 
     def pluck(column_name)
       [@pluck_values[column_name]] * @results.size
+    end
+
+    def maximum(column_name)
+      @maximum_values[column_name]
+    end
+
+    def minimum(column_name)
+      @minimum_values[column_name]
     end
 
     class AppliedExpression < Struct.new(:type, :args)

--- a/test/unit/default_order_by_tests.rb
+++ b/test/unit/default_order_by_tests.rb
@@ -1,0 +1,117 @@
+require 'assert'
+require 'ardb/default_order_by'
+
+require 'ardb/record_spy'
+
+module Ardb::DefaultOrderBy
+
+  class UnitTests < Assert::Context
+    desc "Ardb::DefaultOrderBy"
+    setup do
+      order_by_attribute = @order_by_attribute = Factory.string.to_sym
+      @scope_proc = proc{ self.class.where(:grouping => self.grouping) }
+      @record_class = Ardb::RecordSpy.new do
+        include Ardb::DefaultOrderBy
+        attr_accessor order_by_attribute, :grouping
+      end
+    end
+    subject{ @record_class }
+
+    should have_imeths :default_order_by
+    should have_imeths :ardb_default_order_by_config
+
+    should "know its default attribute, preprocessor and separator" do
+      assert_equal :order_by, DEFAULT_ATTRIBUTE
+      record = subject.new
+      assert_equal subject.scoped, record.instance_eval(&DEFAULT_SCOPE_PROC)
+    end
+
+    should "not have any default-order-by config by default" do
+      assert_equal({}, subject.ardb_default_order_by_config)
+    end
+
+    should "default its config using `default_order_by`" do
+      subject.default_order_by
+
+      config = subject.ardb_default_order_by_config
+      assert_equal DEFAULT_ATTRIBUTE, config[:attribute]
+      assert_same DEFAULT_SCOPE_PROC, config[:scope_proc]
+    end
+
+    should "allow customizing the config using `default_order_by`" do
+      subject.default_order_by({
+        :attribute => @order_by_attribute,
+        :scope     => @scope_proc
+      })
+
+      config = subject.ardb_default_order_by_config
+      assert_equal @order_by_attribute, config[:attribute]
+      assert_same @scope_proc, config[:scope_proc]
+    end
+
+    should "add callbacks using `default_order_by`" do
+      subject.default_order_by
+
+      callback = subject.callbacks.find{ |v| v.type == :before_validation }
+      assert_not_nil callback
+      assert_equal [:ardb_default_order_by], callback.args
+      assert_equal({ :on => :create }, callback.options)
+    end
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @record_class.default_order_by({
+        :attribute => @order_by_attribute,
+        :scope     => @scope_proc
+      })
+      @current_max = Factory.integer
+      @record_class.relation_spy.maximum_values[@order_by_attribute] = @current_max
+
+      @record = @record_class.new
+      @record.grouping = Factory.string
+    end
+    subject{ @record }
+
+    should "allow resetting its order-by to the current max + 1" do
+      assert_not_equal @current_max + 1, subject.send(@order_by_attribute)
+      subject.instance_eval{ reset_order_by }
+      assert_equal @current_max + 1, subject.send(@order_by_attribute)
+    end
+
+    should "reset its order-by to a start value when there isn't a current max" do
+      @record_class.relation_spy.maximum_values.delete(@order_by_attribute)
+
+      subject.instance_eval{ reset_order_by }
+      assert_equal 1, subject.send(@order_by_attribute)
+    end
+
+    should "use the configured scope when resetting its order-by" do
+      assert_empty @record_class.relation_spy.applied
+      subject.instance_eval{ reset_order_by }
+
+      assert_equal 1, @record_class.relation_spy.applied.size
+      applied_expression = @record_class.relation_spy.applied.last
+      assert_equal :where, applied_expression.type
+      assert_equal [{ :grouping => subject.grouping }], applied_expression.args
+    end
+
+    should "reset its order-by using `ardb_default_order_by`" do
+      assert_not_equal @current_max + 1, subject.send(@order_by_attribute)
+      subject.instance_eval{ ardb_default_order_by }
+      assert_equal @current_max + 1, subject.send(@order_by_attribute)
+    end
+
+    should "not reset its order-by if its already set using `ardb_default_order_by`" do
+      current_order_by = Factory.integer
+      subject.send("#{@order_by_attribute}=", current_order_by)
+      subject.instance_eval{ ardb_default_order_by }
+
+      assert_equal current_order_by, subject.send(@order_by_attribute)
+    end
+
+  end
+
+end


### PR DESCRIPTION
This adds a default order by mixin that provides the logic for
automatically defaulting a record to the next available "order-by"
value. This is intended to make it simple to easy order a set of
records when they are initially created.

The mixin adds a before validation callback that will run a query
to check for the current max order by value in the DB. It will then
set its order by value to the current max + 1. This makes records
order by default in the order they are created.

The mixin also allows providing a custom scope proc. This will be
used when determining the current max order by value. This can be
used to group or scope order by values. For example, if all the
records have a grouping and each grouping of records should be
ordered separately then the scope can be used to scope the current
max using the records grouping.

The mixin only sets the order by before validation on create when
it hasn't been given a custom value. The order by can be reset to
the next highest value at anytime though by calling the
`reset_order_by` method. This can be used with callbacks to reset
a records order by when an attribute changes and, for example, it
switches from one grouping to another.

@kellyredding - Ready for review. This slightly changes the interface from how we previously did this mixin:

```ruby
# Old Interface
default_order_by{ self.class.project_id_is(self.project_id) }
# New Interface
default_order_by :scope => proc{ self.class.project_id_is(self.project_id) }
```

I chose this for consistency with `HasSlug` and because this version now also allows customizing the attribute that is defaulted:

```ruby
default_order_by({
  :attribute => :custom_attr,
  :scope    => proc{ self.class.project_id_is(self.project_id) }
})
```