### PR TITLE
Use `MuchPlugin` in other mixins

### DIFF
--- a/lib/ardb/adapter_spy.rb
+++ b/lib/ardb/adapter_spy.rb
@@ -1,6 +1,9 @@
+require 'much-plugin'
+
 module Ardb
 
   module AdapterSpy
+    include MuchPlugin
 
     def self.new(&block)
       block ||= proc{ }
@@ -9,10 +12,8 @@ module Ardb
       record_spy
     end
 
-    def self.included(klass)
-      klass.class_eval do
-        include InstanceMethods
-      end
+    plugin_included do
+      include InstanceMethods
     end
 
     module InstanceMethods

--- a/lib/ardb/has_slug.rb
+++ b/lib/ardb/has_slug.rb
@@ -1,19 +1,20 @@
+require 'much-plugin'
+
 module Ardb
 
   module HasSlug
+    include MuchPlugin
 
     DEFAULT_ATTRIBUTE    = :slug
     DEFAULT_PREPROCESSOR = :downcase
     DEFAULT_SEPARATOR    = '-'.freeze
 
-    def self.included(klass)
-      klass.class_eval do
-        extend ClassMethods
-        include InstanceMethods
+    plugin_included do
+      extend ClassMethods
+      include InstanceMethods
 
-        @ardb_has_slug_config = {}
+      @ardb_has_slug_config = {}
 
-      end
     end
 
     module ClassMethods

--- a/lib/ardb/record_spy.rb
+++ b/lib/ardb/record_spy.rb
@@ -1,9 +1,11 @@
 require 'arel'
+require 'much-plugin'
 require 'ardb/relation_spy'
 
 module Ardb
 
   module RecordSpy
+    include MuchPlugin
 
     def self.new(&block)
       block ||= proc{ }
@@ -12,11 +14,9 @@ module Ardb
       record_spy
     end
 
-    def self.included(klass)
-      klass.class_eval do
-        extend ClassMethods
-        include InstanceMethods
-      end
+    plugin_included do
+      extend ClassMethods
+      include InstanceMethods
     end
 
     module ClassMethods

--- a/lib/ardb/use_db_default.rb
+++ b/lib/ardb/use_db_default.rb
@@ -1,17 +1,18 @@
+require 'much-plugin'
+
 module Ardb
 
   module UseDbDefault
+    include MuchPlugin
 
-    def self.included(klass)
-      klass.class_eval do
-        extend ClassMethods
-        include InstanceMethods
+    plugin_included do
+      extend ClassMethods
+      include InstanceMethods
 
-        @ardb_use_db_default_attrs = []
+      @ardb_use_db_default_attrs = []
 
-        around_create :ardb_allow_db_to_default_attrs
+      around_create :ardb_allow_db_to_default_attrs
 
-      end
     end
 
     module ClassMethods

--- a/test/unit/adapter_spy_tests.rb
+++ b/test/unit/adapter_spy_tests.rb
@@ -1,6 +1,8 @@
 require 'assert'
 require 'ardb/adapter_spy'
 
+require 'much-plugin'
+
 module Ardb::AdapterSpy
 
   class MyAdapter
@@ -25,7 +27,11 @@ module Ardb::AdapterSpy
     should have_imeths :create_db_called?, :create_db
     should have_imeths :migrate_db_called?, :migrate_db
 
-    should "included the record spy instance methods" do
+    should "use much-plugin" do
+      assert_includes MuchPlugin, Ardb::AdapterSpy
+    end
+
+    should "included the adapter spy instance methods" do
       assert_includes Ardb::AdapterSpy::InstanceMethods, subject.class
     end
 

--- a/test/unit/default_order_by_tests.rb
+++ b/test/unit/default_order_by_tests.rb
@@ -1,6 +1,7 @@
 require 'assert'
 require 'ardb/default_order_by'
 
+require 'much-plugin'
 require 'ardb/record_spy'
 
 module Ardb::DefaultOrderBy
@@ -19,6 +20,10 @@ module Ardb::DefaultOrderBy
 
     should have_imeths :default_order_by
     should have_imeths :ardb_default_order_by_config
+
+    should "use much-plugin" do
+      assert_includes MuchPlugin, Ardb::DefaultOrderBy
+    end
 
     should "know its default attribute, preprocessor and separator" do
       assert_equal :order_by, DEFAULT_ATTRIBUTE

--- a/test/unit/has_slug_tests.rb
+++ b/test/unit/has_slug_tests.rb
@@ -1,6 +1,7 @@
 require 'assert'
 require 'ardb/has_slug'
 
+require 'much-plugin'
 require 'ardb/record_spy'
 
 module Ardb::HasSlug
@@ -28,6 +29,10 @@ module Ardb::HasSlug
 
     should have_imeths :has_slug
     should have_imeths :ardb_has_slug_config
+
+    should "use much-plugin" do
+      assert_includes MuchPlugin, Ardb::UseDbDefault
+    end
 
     should "know its default attribute, preprocessor and separator" do
       assert_equal :slug,     DEFAULT_ATTRIBUTE

--- a/test/unit/record_spy_tests.rb
+++ b/test/unit/record_spy_tests.rb
@@ -1,6 +1,8 @@
 require 'assert'
 require 'ardb/record_spy'
 
+require 'much-plugin'
+
 module Ardb::RecordSpy
 
   class UnitTests < Assert::Context
@@ -38,6 +40,10 @@ module Ardb::RecordSpy
     should have_imeths :select, :from, :includes, :joins, :where
     should have_imeths :group, :having, :order, :reverse_order, :readonly
     should have_imeths :limit, :offset, :merge, :except, :only
+
+    should "use much-plugin" do
+      assert_includes MuchPlugin, Ardb::RecordSpy
+    end
 
     should "allow reading and writing the record's table name" do
       subject.table_name = 'my_records'

--- a/test/unit/use_db_default_tests.rb
+++ b/test/unit/use_db_default_tests.rb
@@ -1,6 +1,7 @@
 require 'assert'
 require 'ardb/use_db_default'
 
+require 'much-plugin'
 require 'ardb/record_spy'
 
 module Ardb::UseDbDefault
@@ -16,6 +17,10 @@ module Ardb::UseDbDefault
     subject{ @record_class }
 
     should have_imeths :use_db_default, :ardb_use_db_default_attrs
+
+    should "use much-plugin" do
+      assert_includes MuchPlugin, Ardb::UseDbDefault
+    end
 
     should "know its use db default attrs" do
       assert_equal [], subject.ardb_use_db_default_attrs


### PR DESCRIPTION
This updates the other mixins to use `MuchPlugin` now that its
being brought in. This provides protection from included logic
getting run multiple times. This doesn't change any functionality
of how the mixins work.

@kellyredding - Ready for review.