### PR TITLE
Allow not dumping schema when migrating db

### DIFF
--- a/lib/ardb/runner/migrate_command.rb
+++ b/lib/ardb/runner/migrate_command.rb
@@ -14,7 +14,7 @@ class Ardb::Runner::MigrateCommand
     begin
       Ardb.init
       @adapter.migrate_db
-      @adapter.dump_schema
+      @adapter.dump_schema unless ENV['ARDB_MIGRATE_NO_SCHEMA']
     rescue Ardb::Runner::CmdError => e
       raise e
     rescue StandardError => e

--- a/test/unit/runner/migrate_command_tests.rb
+++ b/test/unit/runner/migrate_command_tests.rb
@@ -31,16 +31,40 @@ class Ardb::Runner::MigrateCommand
 
   end
 
-  class RunTests < InitTests
+  class RunSetupTests < InitTests
     desc "and run"
+
+  end
+
+  class RunTests < RunSetupTests
     setup do
       @command.run
     end
 
     should "initialize Ardb, migrate the db and dump schema via the adapter" do
-      assert_equal true, @ardb_init_called
-      assert_equal true, @adapter_spy.migrate_db_called?
-      assert_equal true, @adapter_spy.dump_schema_called?
+      assert_true @ardb_init_called
+      assert_true @adapter_spy.migrate_db_called?
+      assert_true @adapter_spy.dump_schema_called?
+    end
+
+  end
+
+  class RunWithNoSchemaEnvVarTests < RunSetupTests
+    desc "with no schema dump env var set"
+    setup do
+      @current_no_schema = ENV['ARDB_MIGRATE_NO_SCHEMA']
+      ENV['ARDB_MIGRATE_NO_SCHEMA'] = 'yes'
+
+      @command.run
+    end
+    teardown do
+      ENV['ARDB_MIGRATE_NO_SCHEMA'] = @current_no_schema
+    end
+
+    should "initialize Ardb and migrate the db but not dump schema" do
+      assert_true  @ardb_init_called
+      assert_true  @adapter_spy.migrate_db_called?
+      assert_false @adapter_spy.dump_schema_called?
     end
 
   end


### PR DESCRIPTION
This updates the migrate command to not always dump the schema. If
the no schema env var is set then it won't dump the schema after it
migrates. This is convenient when deploying migrations and using
a sql schema. The bins needed to dump the SQL schema may not be
available on the machine running the migration. Also, the schema
should have been dumped when the migration was run locally. It
doesn't need to be dumped again by the server.

@kellyredding - Ready for review.