### PR TITLE
move connect command core logic into a `connect_db` adapter method

### DIFF
--- a/lib/ardb/adapter/base.rb
+++ b/lib/ardb/adapter/base.rb
@@ -21,6 +21,10 @@ class Ardb::Adapter
     def create_db(*args); raise NotImplementedError; end
     def drop_db(*args);   raise NotImplementedError; end
 
+    def connect_db
+      ActiveRecord::Base.connection
+    end
+
     def migrate_db
       verbose = ENV["MIGRATE_QUIET"].nil?
       version = ENV["MIGRATE_VERSION"] ? ENV["MIGRATE_VERSION"].to_i : nil

--- a/lib/ardb/adapter_spy.rb
+++ b/lib/ardb/adapter_spy.rb
@@ -20,7 +20,7 @@ module Ardb
       attr_accessor :drop_tables_called_count
       attr_accessor :dump_schema_called_count, :load_schema_called_count
       attr_accessor :drop_db_called_count, :create_db_called_count
-      attr_accessor :migrate_db_called_count
+      attr_accessor :connect_db_called_count, :migrate_db_called_count
 
       def drop_tables_called_count
         @drop_tables_called_count ||= 0
@@ -80,6 +80,18 @@ module Ardb
 
       def create_db(*args, &block)
         self.create_db_called_count += 1
+      end
+
+      def connect_db_called_count
+        @connect_db_called_count ||= 0
+      end
+
+      def connect_db_called?
+        self.connect_db_called_count > 0
+      end
+
+      def connect_db(*args, &block)
+        self.connect_db_called_count += 1
       end
 
       def migrate_db_called_count

--- a/lib/ardb/runner/connect_command.rb
+++ b/lib/ardb/runner/connect_command.rb
@@ -4,16 +4,22 @@ class Ardb::Runner
 
   class ConnectCommand
 
+    def initialize(out_io = nil, err_io = nil)
+      @out_io = out_io || $stdout
+      @err_io = err_io || $stderr
+      @adapter = Ardb::Adapter.send(Ardb.config.db.adapter)
+    end
+
     def run
       begin
         Ardb.init
-        ActiveRecord::Base.connection
-        $stdout.puts "connected to #{Ardb.config.db.adapter} db `#{Ardb.config.db.database}`"
+        @adapter.connect_db
+        @out_io.puts "connected to #{Ardb.config.db.adapter} db `#{Ardb.config.db.database}`"
       rescue Ardb::Runner::CmdError => e
         raise e
-      rescue Exception => e
-        $stderr.puts e, *e.backtrace
-        $stderr.puts "error connecting to #{Ardb.config.db.database.inspect} database"\
+      rescue StandardError => e
+        @err_io.puts e, *e.backtrace
+        @err_io.puts "error connecting to #{Ardb.config.db.database.inspect} database"\
                      " with #{Ardb.config.db_settings.inspect}"
         raise Ardb::Runner::CmdFail
       end

--- a/lib/ardb/test_helpers.rb
+++ b/lib/ardb/test_helpers.rb
@@ -39,6 +39,17 @@ module Ardb
       end
     end
 
+    def connect_db!
+      Ardb.adapter.connect_db
+    end
+
+    def connect_db
+      @connect_db ||= begin
+        self.connect_db!
+        true
+      end
+    end
+
     def migrate_db!
       Ardb.adapter.migrate_db
     end

--- a/test/unit/adapter_spy_tests.rb
+++ b/test/unit/adapter_spy_tests.rb
@@ -13,12 +13,13 @@ module Ardb::AdapterSpy
     should have_accessors :drop_tables_called_count
     should have_accessors :dump_schema_called_count, :load_schema_called_count
     should have_accessors :drop_db_called_count, :create_db_called_count
-    should have_accessors :migrate_db_called_count
+    should have_accessors :connect_db_called_count, :migrate_db_called_count
     should have_imeths :drop_tables_called?, :drop_tables
     should have_imeths :dump_schema_called?, :dump_schema
     should have_imeths :load_schema_called?, :load_schema
     should have_imeths :drop_db_called?, :drop_db
     should have_imeths :create_db_called?, :create_db
+    should have_imeths :connect_db_called?, :connect_db
     should have_imeths :migrate_db_called?, :migrate_db
 
     should "included the record spy instance methods" do
@@ -31,6 +32,7 @@ module Ardb::AdapterSpy
       assert_equal 0, subject.load_schema_called_count
       assert_equal 0, subject.drop_db_called_count
       assert_equal 0, subject.create_db_called_count
+      assert_equal 0, subject.connect_db_called_count
       assert_equal 0, subject.migrate_db_called_count
     end
 
@@ -64,6 +66,11 @@ module Ardb::AdapterSpy
       subject.migrate_db
       assert_equal 1, subject.migrate_db_called_count
       assert_equal true, subject.migrate_db_called?
+
+      assert_equal false, subject.connect_db_called?
+      subject.connect_db
+      assert_equal 1, subject.connect_db_called_count
+      assert_equal true, subject.connect_db_called?
     end
 
   end

--- a/test/unit/runner/connect_command_tests.rb
+++ b/test/unit/runner/connect_command_tests.rb
@@ -1,16 +1,71 @@
 require 'assert'
 require 'ardb/runner/connect_command'
 
+require 'ardb/adapter_spy'
+
 class Ardb::Runner::ConnectCommand
 
   class UnitTests < Assert::Context
     desc "Ardb::Runner::ConnectCommand"
     setup do
-      @cmd = Ardb::Runner::ConnectCommand.new
+      @command_class = Ardb::Runner::ConnectCommand
     end
-    subject{ @cmd }
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @adapter_spy = Class.new{ include Ardb::AdapterSpy }.new
+      Assert.stub(Ardb::Adapter, Ardb.config.db.adapter.to_sym){ @adapter_spy }
+
+      @ardb_init_called = false
+      Assert.stub(Ardb, :init){ @ardb_init_called = true }
+
+      # provide an output and error IO to avoid using $stdout/$stderr in tests
+      out_io = err_io = StringIO.new
+      @command = @command_class.new(out_io, err_io)
+    end
+    subject{ @command }
 
     should have_imeths :run
+
+  end
+
+  class RunTests < InitTests
+    desc "and run"
+    setup do
+      @command.run
+    end
+
+    should "initialize ardb and connect to the db via the adapter" do
+      assert_true @ardb_init_called
+      assert_true @adapter_spy.connect_db_called?
+    end
+
+  end
+
+  class RunWithCmdErrorTests < InitTests
+    desc "and run with command errors"
+    setup do
+      Assert.stub(@adapter_spy, :connect_db){ raise Ardb::Runner::CmdError.new }
+    end
+
+    should "not handle the error" do
+      assert_raises(Ardb::Runner::CmdError){ subject.run }
+    end
+
+  end
+
+  class RunWithStandardErrorTests < InitTests
+    desc "and run with a standard error"
+    setup do
+      Assert.stub(@adapter_spy, :connect_db){ raise StandardError.new }
+    end
+
+    should "raise a CmdFail error" do
+      assert_raises(Ardb::Runner::CmdFail){ subject.run }
+    end
 
   end
 

--- a/test/unit/runner/create_command_tests.rb
+++ b/test/unit/runner/create_command_tests.rb
@@ -1,6 +1,7 @@
 require 'assert'
-require 'ardb/adapter_spy'
 require 'ardb/runner/create_command'
+
+require 'ardb/adapter_spy'
 
 class Ardb::Runner::CreateCommand
 

--- a/test/unit/runner/drop_command_tests.rb
+++ b/test/unit/runner/drop_command_tests.rb
@@ -1,6 +1,7 @@
 require 'assert'
-require 'ardb/adapter_spy'
 require 'ardb/runner/drop_command'
+
+require 'ardb/adapter_spy'
 
 class Ardb::Runner::DropCommand
 

--- a/test/unit/runner/migrate_command_tests.rb
+++ b/test/unit/runner/migrate_command_tests.rb
@@ -1,6 +1,7 @@
 require 'assert'
-require 'ardb/adapter_spy'
 require 'ardb/runner/migrate_command'
+
+require 'ardb/adapter_spy'
 
 class Ardb::Runner::MigrateCommand
 
@@ -41,7 +42,7 @@ class Ardb::Runner::MigrateCommand
       @command.run
     end
 
-    should "initialize Ardb, migrate the db and dump schema via the adapter" do
+    should "initialize ardb, migrate the db and dump schema via the adapter" do
       assert_true @ardb_init_called
       assert_true @adapter_spy.migrate_db_called?
       assert_true @adapter_spy.dump_schema_called?
@@ -61,7 +62,7 @@ class Ardb::Runner::MigrateCommand
       ENV['ARDB_MIGRATE_NO_SCHEMA'] = @current_no_schema
     end
 
-    should "initialize Ardb and migrate the db but not dump schema" do
+    should "initialize ardb and migrate the db but not dump schema" do
       assert_true  @ardb_init_called
       assert_true  @adapter_spy.migrate_db_called?
       assert_false @adapter_spy.dump_schema_called?
@@ -81,7 +82,7 @@ class Ardb::Runner::MigrateCommand
 
   end
 
-  class RunWithUnspecifiedErrorTests < InitTests
+  class RunWithStandardErrorTests < InitTests
     desc "and run with a standard error"
     setup do
       Assert.stub(@adapter_spy, :migrate_db){ raise StandardError.new }

--- a/test/unit/test_helpers_tests.rb
+++ b/test/unit/test_helpers_tests.rb
@@ -11,7 +11,8 @@ module Ardb::TestHelpers
 
     should have_imeths :drop_tables, :load_schema
     should have_imeths :create_db!, :create_db, :drop_db!, :drop_db
-    should have_imeths :migrate_db!, :migrate_db, :reset_db, :reset_db!
+    should have_imeths :connect_db!, :connect_db, :migrate_db!, :migrate_db
+    should have_imeths :reset_db, :reset_db!
 
   end
 
@@ -87,6 +88,27 @@ module Ardb::TestHelpers
       assert_equal 1, @adapter_spy.drop_db_called_count
       subject.drop_db!
       assert_equal 2, @adapter_spy.drop_db_called_count
+    end
+
+  end
+
+  class ConnectDbTests < UsageTests
+    desc "connect db methods"
+
+    should "tell the adapter to connect to the db only once" do
+      assert_equal 0, @adapter_spy.connect_db_called_count
+      subject.connect_db
+      assert_equal 1, @adapter_spy.connect_db_called_count
+      subject.connect_db
+      assert_equal 1, @adapter_spy.connect_db_called_count
+    end
+
+    should "force the adapter to connect to the db" do
+      assert_equal 0, @adapter_spy.connect_db_called_count
+      subject.connect_db!
+      assert_equal 1, @adapter_spy.connect_db_called_count
+      subject.connect_db!
+      assert_equal 2, @adapter_spy.connect_db_called_count
     end
 
   end


### PR DESCRIPTION
This centralizes all command behavior and makes it accessible in
a non CLI manner via the adapter.  This keeps the connect logic
consistent with the migrate/etc logic.

To support this, the adapter spy now have "connect db" methods and
the test helpers now have "connect db methods.

This also includes some test cleanups and makes the connect command
tests more robust.  They now closely match the migrate command tests.

@jcredding ready for review.