### PR TITLE
rework CLI sub command handling and framework

### DIFF
--- a/bin/ardb
+++ b/bin/ardb
@@ -4,4 +4,4 @@
 #
 
 require 'ardb/cli'
-Ardb::CLI.run *ARGV
+Ardb::CLI.run ARGV

--- a/lib/ardb/clirb.rb
+++ b/lib/ardb/clirb.rb
@@ -1,0 +1,58 @@
+module Ardb
+
+  class CLIRB  # Version 1.0.0, https://github.com/redding/cli.rb
+    Error    = Class.new(RuntimeError);
+    HelpExit = Class.new(RuntimeError); VersionExit = Class.new(RuntimeError)
+    attr_reader :argv, :args, :opts, :data
+
+    def initialize(&block)
+      @options = []; instance_eval(&block) if block
+      require 'optparse'
+      @data, @args, @opts = [], [], {}; @parser = OptionParser.new do |p|
+        p.banner = ''; @options.each do |o|
+          @opts[o.name] = o.value; p.on(*o.parser_args){ |v| @opts[o.name] = v }
+        end
+        p.on_tail('--version', ''){ |v| raise VersionExit, v.to_s }
+        p.on_tail('--help',    ''){ |v| raise HelpExit,    v.to_s }
+      end
+    end
+
+    def option(*args); @options << Option.new(*args); end
+    def parse!(argv)
+      @args = (argv || []).dup.tap do |args_list|
+        begin; @parser.parse!(args_list)
+        rescue OptionParser::ParseError => err; raise Error, err.message; end
+      end; @data = @args + [@opts]
+    end
+    def to_s; @parser.to_s; end
+    def inspect
+      "#<#{self.class}:#{'0x0%x' % (object_id << 1)} @data=#{@data.inspect}>"
+    end
+
+    class Option
+      attr_reader :name, :opt_name, :desc, :abbrev, :value, :klass, :parser_args
+
+      def initialize(name, *args)
+        settings, @desc = args.last.kind_of?(::Hash) ? args.pop : {}, args.pop || ''
+        @name, @opt_name, @abbrev = parse_name_values(name, settings[:abbrev])
+        @value, @klass = gvalinfo(settings[:value])
+        @parser_args = if [TrueClass, FalseClass, NilClass].include?(@klass)
+          ["-#{@abbrev}", "--[no-]#{@opt_name}", @desc]
+        else
+          ["-#{@abbrev}", "--#{@opt_name} #{@opt_name.upcase}", @klass, @desc]
+        end
+      end
+
+      private
+
+      def parse_name_values(name, custom_abbrev)
+        [ (processed_name = name.to_s.strip.downcase), processed_name.gsub('_', '-'),
+          custom_abbrev || processed_name.gsub(/[^a-z]/, '').chars.first || 'a'
+        ]
+      end
+      def gvalinfo(v); v.kind_of?(Class) ? [nil,gklass(v)] : [v,gklass(v.class)]; end
+      def gklass(k); k == Fixnum ? Integer : k; end
+    end
+  end
+
+end

--- a/test/unit/cli_tests.rb
+++ b/test/unit/cli_tests.rb
@@ -1,0 +1,290 @@
+require 'assert'
+require 'ardb/cli'
+
+class Ardb::CLI
+
+  class UnitTests < Assert::Context
+    desc "Ardb::CLI"
+    setup do
+      @cli_class = Ardb::CLI
+    end
+    subject{ @cli_class }
+
+    should have_imeths :run
+
+    should "build and run an instance of itself using `run`" do
+      cli_spy = CLISpy.new
+      Assert.stub(subject, :new).with{ cli_spy }
+
+      args = [Factory.string]
+      subject.run(args)
+      assert_equal args, cli_spy.run_called_with
+    end
+
+    should "know its commands" do
+      assert_equal 0, COMMANDS.size
+
+      assert_instance_of InvalidCommand, COMMANDS[Factory.string]
+    end
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @kernel_spy = KernelSpy.new
+      @stdout = IOSpy.new
+      @stderr = IOSpy.new
+
+      @cli = @cli_class.new(@kernel_spy, @stdout, @stderr)
+    end
+    subject{ @cli }
+
+    should have_imeths :run
+
+  end
+
+  class RunSetupTests < InitTests
+    setup do
+      @command_name = Factory.string
+      @argv = [@command_name, Factory.string]
+
+      @command_class = Class.new
+      COMMANDS[@command_name] = @command_class
+
+      @command_spy = CommandSpy.new
+      Assert.stub(@command_class, :new).with(@argv){ @command_spy }
+
+      @invalid_command = InvalidCommand.new(@command_name)
+    end
+    teardown do
+      COMMANDS.delete(@command_name)
+    end
+
+  end
+
+  class RunTests < RunSetupTests
+    desc "and run"
+    setup do
+      @cli.run(@argv)
+    end
+
+    should "have init and run the command" do
+      assert_true @command_spy.init_called
+      assert_true @command_spy.run_called
+    end
+
+    should "have successfully exited" do
+      assert_equal 0, @kernel_spy.exit_status
+    end
+
+  end
+
+  class RunWithNoArgsTests < RunSetupTests
+    desc "and run with no args"
+    setup do
+      @cli.run([])
+    end
+
+    should "output the invalid command's help" do
+      assert_equal @invalid_command.help, @stdout.read
+      assert_empty @stderr.read
+    end
+
+    should "have successfully exited" do
+      assert_equal 0, @kernel_spy.exit_status
+    end
+
+  end
+
+  class RunWithInvalidCommandTests < RunSetupTests
+    desc "and run with an invalid command"
+    setup do
+      @name = Factory.string
+      @argv.unshift(@name)
+      @cli.run(@argv)
+    end
+
+    should "output that it is invalid and output the invalid command's help" do
+      exp = "'#{@name}' is not a command.\n\n"
+      assert_equal exp, @stderr.read
+      assert_equal @invalid_command.help, @stdout.read
+    end
+
+    should "have unsuccessfully exited" do
+      assert_equal 1, @kernel_spy.exit_status
+    end
+
+  end
+
+  class RunWithHelpTests < RunSetupTests
+    desc "and run with the help switch"
+    setup do
+      @cli.run([ '--help' ])
+    end
+
+    should "output the invalid command's help" do
+      assert_equal @invalid_command.help, @stdout.read
+      assert_empty @stderr.read
+    end
+
+    should "have successfully exited" do
+      assert_equal 0, @kernel_spy.exit_status
+    end
+
+  end
+
+  class RunWithVersionTests < RunSetupTests
+    desc "and run with the version switch"
+    setup do
+      @cli.run([ '--version' ])
+    end
+
+    should "output its version" do
+      assert_equal "#{Ardb::VERSION}\n", @stdout.read
+      assert_empty @stderr.read
+    end
+
+    should "have successfully exited" do
+      assert_equal 0, @kernel_spy.exit_status
+    end
+
+  end
+
+  class RunWithErrorTests < RunSetupTests
+    setup do
+      @exception = RuntimeError.new(Factory.string)
+      Assert.stub(@command_class, :new).with(@argv){ raise @exception }
+      @cli.run(@argv)
+    end
+
+    should "have output an error message" do
+      exp = "#{@exception.class}: #{@exception.message}\n" \
+            "#{@exception.backtrace.join("\n")}\n"
+      assert_equal exp, @stderr.read
+      assert_empty @stdout.read
+    end
+
+    should "have unsuccessfully exited" do
+      assert_equal 1, @kernel_spy.exit_status
+    end
+
+  end
+
+  class InvalidCommandTests < UnitTests
+    desc "InvalidCommand"
+    setup do
+      @name = Factory.string
+      @command_class = InvalidCommand
+      @cmd = @command_class.new(@name)
+    end
+    subject{ @cmd }
+
+    should have_readers :name, :argv, :clirb
+    should have_imeths :new, :init, :run, :help
+
+    should "know its attrs" do
+      assert_equal @name, subject.name
+      assert_equal [],    subject.argv
+
+      assert_instance_of Ardb::CLIRB, subject.clirb
+    end
+
+    should "set its argv and return itself using `new`" do
+      args = [Factory.string, Factory.string]
+      result = subject.new(args)
+      assert_same subject, result
+      assert_equal [@name, args].flatten, subject.argv
+    end
+
+    should "parse its argv when `init`" do
+      subject.new([ '--help' ])
+      assert_raises(Ardb::CLIRB::HelpExit){ subject.init }
+      subject.new([ '--version' ])
+      assert_raises(Ardb::CLIRB::VersionExit){ subject.init }
+    end
+
+    should "raise a help exit if its argv is empty when `init`" do
+      cmd = @command_class.new(nil)
+      cmd.new([])
+      assert_raises(Ardb::CLIRB::HelpExit){ cmd.init }
+
+      cli = @command_class.new("")
+      cli.new([])
+      assert_raises(Ardb::CLIRB::HelpExit){ cli.init }
+    end
+
+    should "raise an invalid command error when run" do
+      assert_raises(InvalidCommandError){ subject.run }
+    end
+
+    should "know its help" do
+      exp = "Usage: ardb [COMMAND] [options]\n\n" \
+            "Commands: #{COMMANDS.keys.sort.join(', ')}\n" \
+            "Options: #{subject.clirb}"
+      assert_equal exp, subject.help
+    end
+
+  end
+
+  class CLISpy
+    attr_reader :run_called_with
+
+    def initialize
+      @run_called_with = nil
+    end
+
+    def run(args)
+      @run_called_with = args
+    end
+  end
+
+  class CommandSpy
+    attr_reader :init_called, :run_called
+
+    def initialize
+      @init_called = false
+      @run_called = false
+    end
+
+    def init
+      @init_called = true
+    end
+
+    def run
+      @run_called = true
+    end
+
+    def help
+      Factory.text
+    end
+  end
+
+  class KernelSpy
+    attr_reader :exit_status
+
+    def initialize
+      @exit_status = nil
+    end
+
+    def exit(code)
+      @exit_status ||= code
+    end
+  end
+
+  class IOSpy
+    def initialize
+      @io = StringIO.new
+    end
+
+    def puts(message)
+      @io.puts message
+    end
+
+    def read
+      @io.rewind
+      @io.read
+    end
+  end
+
+end


### PR DESCRIPTION
This reworks the CLI to handle each sub command using its own CLIRB
config/parser.  This allows the main CLI to have its own options and
help message and each sub command to also have their own options and
help message.

Note: this is part of a large effort to rework the CLI implementation.
Overall, no external behavior changes will happen but the CLI will
be easier to maintain and extend.  Right now this just sets up the
framework so we can move each sub command into it.  After we move
all the sub commands, the runner will just go away.

Note also: there were no CLI specific tests before so this adds some.

@jcredding ready for review.  Note that this is against a feature branch.  I'll probably do each sub command in its own PR and then do a cleanup commit where I remove the runner at the end.  FYI.