### PR TITLE
rework how CLI initializes Ardb and handles clirb exceptions

### DIFF
--- a/lib/ardb.rb
+++ b/lib/ardb.rb
@@ -22,7 +22,7 @@ module Ardb
     end
   end
 
-  def self.init(establish_connection=true)
+  def self.init(establish_connection = true)
     require self.config.db_file
     validate!
     Adapter.init


### PR DESCRIPTION
This makes the CLI in general init Ardb without establishing a
connection regardless of the command - all commands should expect
Ardb to be configured and initialized.

This also updates the sub-commands to not treat clirb parse errors
as command errors.  This breaks the built in clirb error handling
the CLI does.

These were things that were discovered while using the new CLI in
an application.

@jcredding ready for review.