### PR TITLE
Feature: Add `DefaultOrderBy` and use `MuchPlugin

### DIFF
--- a/ardb.gemspec
+++ b/ardb.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency('activerecord',  ["~> 3.2"])
   gem.add_dependency('activesupport', ["~> 3.2"])
+  gem.add_dependency('much-plugin',   ["~> 0.1"])
   gem.add_dependency('ns-options',    ["~> 1.1"])
   gem.add_dependency('scmd',          ["~> 3.0"])
 

--- a/lib/ardb/adapter_spy.rb
+++ b/lib/ardb/adapter_spy.rb
@@ -1,6 +1,9 @@
+require 'much-plugin'
+
 module Ardb
 
   module AdapterSpy
+    include MuchPlugin
 
     def self.new(&block)
       block ||= proc{ }
@@ -9,10 +12,8 @@ module Ardb
       record_spy
     end
 
-    def self.included(klass)
-      klass.class_eval do
-        include InstanceMethods
-      end
+    plugin_included do
+      include InstanceMethods
     end
 
     module InstanceMethods

--- a/lib/ardb/default_order_by.rb
+++ b/lib/ardb/default_order_by.rb
@@ -1,0 +1,59 @@
+require 'much-plugin'
+
+module Ardb
+
+  module DefaultOrderBy
+    include MuchPlugin
+
+    DEFAULT_ATTRIBUTE  = :order_by
+    DEFAULT_SCOPE_PROC = proc{ self.class.scoped }
+
+    plugin_included do
+      extend ClassMethods
+      include InstanceMethods
+
+      @ardb_default_order_by_config = {}
+
+    end
+
+    module ClassMethods
+
+      def default_order_by(options = nil)
+        options ||= {}
+
+        @ardb_default_order_by_config.merge!({
+          :attribute  => options[:attribute] || DEFAULT_ATTRIBUTE,
+          :scope_proc => options[:scope]     || DEFAULT_SCOPE_PROC
+        })
+
+        before_validation :ardb_default_order_by, :on => :create
+      end
+
+      def ardb_default_order_by_config
+        @ardb_default_order_by_config
+      end
+
+    end
+
+    module InstanceMethods
+
+      private
+
+      def reset_order_by
+        attr_name  = self.class.ardb_default_order_by_config[:attribute]
+        scope_proc = self.class.ardb_default_order_by_config[:scope_proc]
+
+        current_max = self.instance_eval(&scope_proc).maximum(attr_name) || 0
+        self.send("#{attr_name}=", current_max + 1)
+      end
+
+      def ardb_default_order_by
+        attr_name = self.class.ardb_default_order_by_config[:attribute]
+        reset_order_by if self.send(attr_name).to_s.empty?
+        true
+      end
+
+    end
+
+  end
+end

--- a/lib/ardb/has_slug.rb
+++ b/lib/ardb/has_slug.rb
@@ -1,19 +1,20 @@
+require 'much-plugin'
+
 module Ardb
 
   module HasSlug
+    include MuchPlugin
 
     DEFAULT_ATTRIBUTE    = :slug
     DEFAULT_PREPROCESSOR = :downcase
     DEFAULT_SEPARATOR    = '-'.freeze
 
-    def self.included(klass)
-      klass.class_eval do
-        extend ClassMethods
-        include InstanceMethods
+    plugin_included do
+      extend ClassMethods
+      include InstanceMethods
 
-        @ardb_has_slug_config = {}
+      @ardb_has_slug_config = {}
 
-      end
     end
 
     module ClassMethods

--- a/lib/ardb/record_spy.rb
+++ b/lib/ardb/record_spy.rb
@@ -1,9 +1,11 @@
 require 'arel'
+require 'much-plugin'
 require 'ardb/relation_spy'
 
 module Ardb
 
   module RecordSpy
+    include MuchPlugin
 
     def self.new(&block)
       block ||= proc{ }
@@ -12,11 +14,9 @@ module Ardb
       record_spy
     end
 
-    def self.included(klass)
-      klass.class_eval do
-        extend ClassMethods
-        include InstanceMethods
-      end
+    plugin_included do
+      extend ClassMethods
+      include InstanceMethods
     end
 
     module ClassMethods

--- a/lib/ardb/relation_spy.rb
+++ b/lib/ardb/relation_spy.rb
@@ -4,13 +4,16 @@ module Ardb
 
     attr_reader :applied
     attr_accessor :limit_value, :offset_value
-    attr_accessor :pluck_values
+    attr_accessor :pluck_values, :maximum_values, :minimum_values
     attr_accessor :results
 
     def initialize
       @applied, @results = [], []
       @offset_value, @limit_value = nil, nil
-      @pluck_values = {}
+
+      @pluck_values   = {}
+      @maximum_values = {}
+      @minimum_values = {}
     end
 
     def initialize_copy(copied_from)
@@ -132,6 +135,14 @@ module Ardb
 
     def pluck(column_name)
       [@pluck_values[column_name]] * @results.size
+    end
+
+    def maximum(column_name)
+      @maximum_values[column_name]
+    end
+
+    def minimum(column_name)
+      @minimum_values[column_name]
     end
 
     class AppliedExpression < Struct.new(:type, :args)

--- a/lib/ardb/use_db_default.rb
+++ b/lib/ardb/use_db_default.rb
@@ -1,17 +1,18 @@
+require 'much-plugin'
+
 module Ardb
 
   module UseDbDefault
+    include MuchPlugin
 
-    def self.included(klass)
-      klass.class_eval do
-        extend ClassMethods
-        include InstanceMethods
+    plugin_included do
+      extend ClassMethods
+      include InstanceMethods
 
-        @ardb_use_db_default_attrs = []
+      @ardb_use_db_default_attrs = []
 
-        around_create :ardb_allow_db_to_default_attrs
+      around_create :ardb_allow_db_to_default_attrs
 
-      end
     end
 
     module ClassMethods

--- a/test/unit/adapter_spy_tests.rb
+++ b/test/unit/adapter_spy_tests.rb
@@ -1,6 +1,8 @@
 require 'assert'
 require 'ardb/adapter_spy'
 
+require 'much-plugin'
+
 module Ardb::AdapterSpy
 
   class UnitTests < Assert::Context
@@ -22,7 +24,11 @@ module Ardb::AdapterSpy
     should have_imeths :connect_db_called?, :connect_db
     should have_imeths :migrate_db_called?, :migrate_db
 
-    should "included the record spy instance methods" do
+    should "use much-plugin" do
+      assert_includes MuchPlugin, Ardb::AdapterSpy
+    end
+
+    should "included the adapter spy instance methods" do
       assert_includes Ardb::AdapterSpy::InstanceMethods, subject.class
     end
 

--- a/test/unit/default_order_by_tests.rb
+++ b/test/unit/default_order_by_tests.rb
@@ -1,6 +1,7 @@
 require 'assert'
 require 'ardb/default_order_by'
 
+require 'much-plugin'
 require 'ardb/record_spy'
 
 module Ardb::DefaultOrderBy
@@ -19,6 +20,10 @@ module Ardb::DefaultOrderBy
 
     should have_imeths :default_order_by
     should have_imeths :ardb_default_order_by_config
+
+    should "use much-plugin" do
+      assert_includes MuchPlugin, Ardb::DefaultOrderBy
+    end
 
     should "know its default attribute, preprocessor and separator" do
       assert_equal :order_by, DEFAULT_ATTRIBUTE

--- a/test/unit/default_order_by_tests.rb
+++ b/test/unit/default_order_by_tests.rb
@@ -1,0 +1,117 @@
+require 'assert'
+require 'ardb/default_order_by'
+
+require 'ardb/record_spy'
+
+module Ardb::DefaultOrderBy
+
+  class UnitTests < Assert::Context
+    desc "Ardb::DefaultOrderBy"
+    setup do
+      order_by_attribute = @order_by_attribute = Factory.string.to_sym
+      @scope_proc = proc{ self.class.where(:grouping => self.grouping) }
+      @record_class = Ardb::RecordSpy.new do
+        include Ardb::DefaultOrderBy
+        attr_accessor order_by_attribute, :grouping
+      end
+    end
+    subject{ @record_class }
+
+    should have_imeths :default_order_by
+    should have_imeths :ardb_default_order_by_config
+
+    should "know its default attribute, preprocessor and separator" do
+      assert_equal :order_by, DEFAULT_ATTRIBUTE
+      record = subject.new
+      assert_equal subject.scoped, record.instance_eval(&DEFAULT_SCOPE_PROC)
+    end
+
+    should "not have any default-order-by config by default" do
+      assert_equal({}, subject.ardb_default_order_by_config)
+    end
+
+    should "default its config using `default_order_by`" do
+      subject.default_order_by
+
+      config = subject.ardb_default_order_by_config
+      assert_equal DEFAULT_ATTRIBUTE, config[:attribute]
+      assert_same DEFAULT_SCOPE_PROC, config[:scope_proc]
+    end
+
+    should "allow customizing the config using `default_order_by`" do
+      subject.default_order_by({
+        :attribute => @order_by_attribute,
+        :scope     => @scope_proc
+      })
+
+      config = subject.ardb_default_order_by_config
+      assert_equal @order_by_attribute, config[:attribute]
+      assert_same @scope_proc, config[:scope_proc]
+    end
+
+    should "add callbacks using `default_order_by`" do
+      subject.default_order_by
+
+      callback = subject.callbacks.find{ |v| v.type == :before_validation }
+      assert_not_nil callback
+      assert_equal [:ardb_default_order_by], callback.args
+      assert_equal({ :on => :create }, callback.options)
+    end
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @record_class.default_order_by({
+        :attribute => @order_by_attribute,
+        :scope     => @scope_proc
+      })
+      @current_max = Factory.integer
+      @record_class.relation_spy.maximum_values[@order_by_attribute] = @current_max
+
+      @record = @record_class.new
+      @record.grouping = Factory.string
+    end
+    subject{ @record }
+
+    should "allow resetting its order-by to the current max + 1" do
+      assert_not_equal @current_max + 1, subject.send(@order_by_attribute)
+      subject.instance_eval{ reset_order_by }
+      assert_equal @current_max + 1, subject.send(@order_by_attribute)
+    end
+
+    should "reset its order-by to a start value when there isn't a current max" do
+      @record_class.relation_spy.maximum_values.delete(@order_by_attribute)
+
+      subject.instance_eval{ reset_order_by }
+      assert_equal 1, subject.send(@order_by_attribute)
+    end
+
+    should "use the configured scope when resetting its order-by" do
+      assert_empty @record_class.relation_spy.applied
+      subject.instance_eval{ reset_order_by }
+
+      assert_equal 1, @record_class.relation_spy.applied.size
+      applied_expression = @record_class.relation_spy.applied.last
+      assert_equal :where, applied_expression.type
+      assert_equal [{ :grouping => subject.grouping }], applied_expression.args
+    end
+
+    should "reset its order-by using `ardb_default_order_by`" do
+      assert_not_equal @current_max + 1, subject.send(@order_by_attribute)
+      subject.instance_eval{ ardb_default_order_by }
+      assert_equal @current_max + 1, subject.send(@order_by_attribute)
+    end
+
+    should "not reset its order-by if its already set using `ardb_default_order_by`" do
+      current_order_by = Factory.integer
+      subject.send("#{@order_by_attribute}=", current_order_by)
+      subject.instance_eval{ ardb_default_order_by }
+
+      assert_equal current_order_by, subject.send(@order_by_attribute)
+    end
+
+  end
+
+end

--- a/test/unit/has_slug_tests.rb
+++ b/test/unit/has_slug_tests.rb
@@ -1,6 +1,7 @@
 require 'assert'
 require 'ardb/has_slug'
 
+require 'much-plugin'
 require 'ardb/record_spy'
 
 module Ardb::HasSlug
@@ -28,6 +29,10 @@ module Ardb::HasSlug
 
     should have_imeths :has_slug
     should have_imeths :ardb_has_slug_config
+
+    should "use much-plugin" do
+      assert_includes MuchPlugin, Ardb::UseDbDefault
+    end
 
     should "know its default attribute, preprocessor and separator" do
       assert_equal :slug,     DEFAULT_ATTRIBUTE

--- a/test/unit/record_spy_tests.rb
+++ b/test/unit/record_spy_tests.rb
@@ -1,6 +1,8 @@
 require 'assert'
 require 'ardb/record_spy'
 
+require 'much-plugin'
+
 module Ardb::RecordSpy
 
   class UnitTests < Assert::Context
@@ -38,6 +40,10 @@ module Ardb::RecordSpy
     should have_imeths :select, :from, :includes, :joins, :where
     should have_imeths :group, :having, :order, :reverse_order, :readonly
     should have_imeths :limit, :offset, :merge, :except, :only
+
+    should "use much-plugin" do
+      assert_includes MuchPlugin, Ardb::RecordSpy
+    end
 
     should "allow reading and writing the record's table name" do
       subject.table_name = 'my_records'

--- a/test/unit/use_db_default_tests.rb
+++ b/test/unit/use_db_default_tests.rb
@@ -1,6 +1,7 @@
 require 'assert'
 require 'ardb/use_db_default'
 
+require 'much-plugin'
 require 'ardb/record_spy'
 
 module Ardb::UseDbDefault
@@ -16,6 +17,10 @@ module Ardb::UseDbDefault
     subject{ @record_class }
 
     should have_imeths :use_db_default, :ardb_use_db_default_attrs
+
+    should "use much-plugin" do
+      assert_includes MuchPlugin, Ardb::UseDbDefault
+    end
 
     should "know its use db default attrs" do
       assert_equal [], subject.ardb_use_db_default_attrs


### PR DESCRIPTION
This adds a default order by mixin and switches to using much-plugin in all of Ardb's mixins.

@kellyredding - FYI.