### PR TITLE
Add requiring all of activerecord to init

### DIFF
--- a/lib/ardb.rb
+++ b/lib/ardb.rb
@@ -23,6 +23,7 @@ module Ardb
   end
 
   def self.init(establish_connection = true)
+    require 'ardb/require_autoloaded_active_record_files'
     require self.config.db_file
     validate!
     Adapter.init

--- a/lib/ardb/require_autoloaded_active_record_files.rb
+++ b/lib/ardb/require_autoloaded_active_record_files.rb
@@ -1,0 +1,69 @@
+# ActiveRecord makes use of autoload to load some of its components as-needed.
+# This doesn't work well with threaded environments, and causes uninitialized
+# constants. To avoid this, this file manually requires the following files that
+# are not required using `require 'active_record'`. Trying to automatically
+# require every file in ActiveRecord is slow and inefficient. Many of the files
+# fail to require and there are some we don't want to require. Thus, this is a
+# manual list of requires.
+
+# To re-build this list of requires, run the following:
+#   bundle exec ruby script/determine_autoloaded_active_record_files.rb
+
+# For compatibility, we require active record first
+require 'active_record'
+
+require 'active_record/aggregations'
+require 'active_record/associations'
+require 'active_record/associations/alias_tracker'
+require 'active_record/associations/association'
+require 'active_record/associations/association_scope'
+require 'active_record/associations/belongs_to_association'
+require 'active_record/associations/belongs_to_polymorphic_association'
+require 'active_record/associations/builder/association'
+require 'active_record/associations/builder/belongs_to'
+require 'active_record/associations/builder/collection_association'
+require 'active_record/associations/builder/has_and_belongs_to_many'
+require 'active_record/associations/builder/has_many'
+require 'active_record/associations/builder/has_one'
+require 'active_record/associations/collection_association'
+require 'active_record/associations/collection_proxy'
+require 'active_record/associations/has_and_belongs_to_many_association'
+require 'active_record/associations/has_many_association'
+require 'active_record/associations/has_many_through_association'
+require 'active_record/associations/has_one_association'
+require 'active_record/associations/has_one_through_association'
+require 'active_record/associations/join_dependency'
+require 'active_record/associations/join_dependency/join_association'
+require 'active_record/associations/join_dependency/join_base'
+require 'active_record/associations/preloader'
+require 'active_record/associations/preloader/association'
+require 'active_record/associations/preloader/belongs_to'
+require 'active_record/associations/preloader/collection_association'
+require 'active_record/associations/preloader/has_and_belongs_to_many'
+require 'active_record/associations/preloader/has_many'
+require 'active_record/associations/preloader/has_many_through'
+require 'active_record/associations/preloader/has_one'
+require 'active_record/associations/preloader/has_one_through'
+require 'active_record/attribute_assignment'
+require 'active_record/attribute_methods/before_type_cast'
+require 'active_record/attribute_methods/deprecated_underscore_read'
+require 'active_record/attribute_methods/dirty'
+require 'active_record/attribute_methods/primary_key'
+require 'active_record/attribute_methods/query'
+require 'active_record/attribute_methods/read'
+require 'active_record/attribute_methods/serialization'
+require 'active_record/attribute_methods/time_zone_conversion'
+require 'active_record/autosave_association'
+require 'active_record/base'
+require 'active_record/dynamic_finder_match'
+require 'active_record/dynamic_scope_match'
+require 'active_record/observer'
+require 'active_record/relation'
+require 'active_record/relation/predicate_builder'
+require 'active_record/result'
+
+# There are also issues with requiring ActiveSupport. This doesn't require every
+# ActiveSupport file though, only ones we've seen cause problems.
+require 'active_support'
+
+require 'active_support/multibyte/chars'

--- a/script/determine_autoloaded_active_record_files.rb
+++ b/script/determine_autoloaded_active_record_files.rb
@@ -1,0 +1,91 @@
+require 'active_record'
+
+# this can be slow, this is one of the reasons this shouldn't be done during
+# the startup of our apps
+gemspec = Gem.loaded_specs['activerecord']
+
+puts "Looking at files in: "
+puts "  #{gemspec.lib_dirs_glob.inspect}"
+
+paths = Dir["#{gemspec.lib_dirs_glob}/**/*.rb"]
+
+# these are regexs for files we want to ignore requiring. for example,
+# generators fail when we try to require them. the others are pieces of active
+# record we don't use in a production environment
+ignored_regexes = [
+  /rails\/generators/,
+  /active_record\/railtie/,
+  /active_record\/migration/,
+  /active_record\/fixtures/,
+  /active_record\/schema/,
+  /active_record\/connection_adapters/,
+  /active_record\/test_case/,
+  /active_record\/coders\/yaml_column/
+]
+
+Result = Struct.new(:file, :state, :reason)
+
+already_required     = []
+needs_to_be_required = []
+ignored              = []
+errored              = []
+
+paths.sort.each do |full_path|
+  relative_path_with_rb = full_path.gsub("#{gemspec.lib_dirs_glob}/", '')
+  relative_path = relative_path_with_rb.gsub(/\.rb\z/, '')
+
+  result = Result.new(relative_path)
+
+  # see if it's ignored
+  ignored_regexes.each do |regex|
+    if relative_path =~ regex
+      result.state  = :ignored
+      result.reason = "matched #{regex}"
+      break
+    end
+  end
+  if result.state == :ignored
+    ignored << result
+    next
+  end
+
+  # try requiring the file
+  begin
+    if result.state = require(relative_path)
+      needs_to_be_required << result
+    else
+      already_required << result
+    end
+  rescue LoadError, SyntaxError => exception
+    result.state  = :errored
+    result.reason = "#{exception.class}: #{exception.message}"
+    errored << result
+  end
+end
+
+puts "Results\n"
+
+puts "Ignored:"
+ignored.each do |result|
+  puts "  #{result.file}"
+  puts "    #{result.reason}"
+end
+puts "\n"
+
+puts "Errored:"
+errored.each do |result|
+  puts "  #{result.file}"
+  puts "    #{result.reason}"
+end
+puts "\n"
+
+puts "Already Required:"
+already_required.each do |result|
+  puts "  #{result.file}"
+end
+puts "\n"
+
+puts "Needs To Be Required:\n"
+needs_to_be_required.each do |result|
+  puts "require '#{result.file}'"
+end


### PR DESCRIPTION
This adds requiring all of activerecord to ardb's init. This avoids
uninitialized constant errors that happen in threaded environments.
Activerecord uses ruby's autoload which isn't threadsafe. This
is intended to avoid autoload by manually requiring all the files
needed. `Ardb.init` should be run when an app is initialized before
any threads are created.

This also adds a script for determining the files that need to be
manually required. This is a tool to use when activerecord is
updated to ensure we are continue requiring any new files that get
added (or stop requiring old files that are removed).

@kellyredding - Ready for review.