### PR TITLE
Add `pool` and `checkout_timeout` options to ardb db config

### DIFF
--- a/lib/ardb.rb
+++ b/lib/ardb.rb
@@ -39,13 +39,15 @@ module Ardb
     include NsOptions::Proxy
 
     namespace :db do
-      option :adapter,  String,  :required => true
-      option :database, String,  :required => true
-      option :encoding, String,  :required => false
-      option :host,     String,  :required => false
-      option :port,     Integer, :required => false
-      option :username, String,  :required => false
-      option :password, String,  :required => false
+      option :adapter,          String,  :required => true
+      option :database,         String,  :required => true
+      option :encoding,         String,  :required => false
+      option :host,             String,  :required => false
+      option :port,             Integer, :required => false
+      option :username,         String,  :required => false
+      option :password,         String,  :required => false
+      option :pool,             Integer, :required => false
+      option :checkout_timeout, Integer, :required => false
     end
 
     option :db_file,         Pathname, :default => ENV['ARDB_DB_FILE']

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -43,13 +43,15 @@ class Ardb::Config
     desc "db namespace"
     subject{ Ardb::Config.db }
 
-    should have_option :adapter,  String,  :required => true
-    should have_option :database, String,  :required => true
-    should have_option :encoding, String,  :required => false
-    should have_option :host,     String,  :required => false
-    should have_option :port,     Integer, :required => false
-    should have_option :username, String,  :required => false
-    should have_option :password, String,  :required => false
+    should have_option :adapter,          String,  :required => true
+    should have_option :database,         String,  :required => true
+    should have_option :encoding,         String,  :required => false
+    should have_option :host,             String,  :required => false
+    should have_option :port,             Integer, :required => false
+    should have_option :username,         String,  :required => false
+    should have_option :password,         String,  :required => false
+    should have_option :pool,             Integer, :required => false
+    should have_option :checkout_timeout, Integer, :required => false
 
   end
 


### PR DESCRIPTION
This exposes a `pool` and `checkout_timeout` option for the ardb
db config. This allows changing activerecord's pool size and the
timeout it uses for checking out a new connection from the pool.
These typically aren't set unless the process is using multiple
threads. This allows more control over the activerecord
configuration in a threaded environment. This also makes it
possible to set all of the common activerecord connection options
using ardb.

@kellyredding - Ready for review.