### PR TITLE
Add `DbTests` assert context

### DIFF
--- a/lib/ardb/db_tests.rb
+++ b/lib/ardb/db_tests.rb
@@ -1,0 +1,15 @@
+require 'active_record'
+require 'assert'
+
+module Ardb
+
+  class DbTests < Assert::Context
+    around do |block|
+      ActiveRecord::Base.transaction do
+        block.call
+        raise ActiveRecord::Rollback
+      end
+    end
+  end
+
+end

--- a/test/unit/db_tests_tests.rb
+++ b/test/unit/db_tests_tests.rb
@@ -1,0 +1,37 @@
+require 'assert'
+require 'ardb/db_tests'
+
+require 'active_record'
+
+class Ardb::DbTests
+
+  class UnitTests < Assert::Context
+    desc "Ardb::DbTests"
+    setup do
+      @transaction_called = false
+      Assert.stub(ActiveRecord::Base, :transaction) do |&block|
+        @transaction_called = true
+        block.call
+      end
+    end
+    subject{ Ardb::DbTests }
+
+    should "be an assert context" do
+      assert subject < Assert::Context
+    end
+
+    should "add an around callback that runs tests in a transaction that rolls back" do
+      assert_equal 1, subject.arounds.size
+      callback = subject.arounds.first
+
+      block_yielded_to = false
+      assert_raises(ActiveRecord::Rollback) do
+        callback.call(proc{ block_yielded_to = true })
+      end
+      assert_true @transaction_called
+      assert_true block_yielded_to
+    end
+
+  end
+
+end


### PR DESCRIPTION
This adds a `DbTests` assert context which can be used to run
tests in a transaction that is rolled back. This is being added
to help with tests that need to interact with a DB. The DB is a
global state for a test suite and this handles automatically
resetting it. This makes it so tests don't have to handle cleaning
up data they created or deal with a dirty global state. Finally,
this also can improve test speed by never committing anything to
the DB.

The `DbTests` relies on the assert testing library but assert is
not being brought in as a formal dependency. The `DbTests` is an
optional helper that doesn't have to be used. Thus, the user of
ardb is required to bring in ardb if they want to use `DbTests`.
If there are ever more test helpers (for assert or other testing
libraries) then we will probably pull this into an ardb assert
combination gem which will require both dependencies.

@kellyredding - Ready for review.