### PR TITLE
Add `escape_like_pattern` helper method to adapters

### DIFF
--- a/lib/ardb.rb
+++ b/lib/ardb.rb
@@ -35,6 +35,10 @@ module Ardb
     end
   end
 
+  def self.escape_like_pattern(pattern, escape_char = nil)
+    self.adapter.escape_like_pattern(pattern, escape_char)
+  end
+
   class Config
     include NsOptions::Proxy
 

--- a/lib/ardb/adapter/base.rb
+++ b/lib/ardb/adapter/base.rb
@@ -15,6 +15,14 @@ class Ardb::Adapter
       @sql_schema_path  = "#{schema_path}.sql"
     end
 
+    def escape_like_pattern(pattern, escape_char = nil)
+      escape_char ||= "\\"
+      pattern = pattern.to_s.dup
+      pattern.gsub!(escape_char){ escape_char * 2 }
+      # don't allow custom wildcards
+      pattern.gsub!(/%|_/){ |wildcard_char| "#{escape_char}#{wildcard_char}" }
+    end
+
     def foreign_key_add_sql(*args);  raise NotImplementedError; end
     def foreign_key_drop_sql(*args); raise NotImplementedError; end
 

--- a/test/unit/adapter/base_tests.rb
+++ b/test/unit/adapter/base_tests.rb
@@ -12,6 +12,7 @@ class Ardb::Adapter::Base
 
     should have_readers :config_settings, :database
     should have_readers :ruby_schema_path, :sql_schema_path
+    should have_imeths :escape_like_pattern
     should have_imeths :foreign_key_add_sql, :foreign_key_drop_sql
     should have_imeths :create_db, :drop_db, :connect_db, :migrate_db
     should have_imeths :load_schema, :load_ruby_schema, :load_sql_schema
@@ -28,6 +29,29 @@ class Ardb::Adapter::Base
     should "know its schema paths" do
       assert_equal "#{Ardb.config.schema_path}.rb",  subject.ruby_schema_path
       assert_equal "#{Ardb.config.schema_path}.sql", subject.sql_schema_path
+    end
+
+    should "know how to escape like patterns" do
+      pattern = "#{Factory.string}%" \
+                "#{Factory.string}_" \
+                "#{Factory.string}\\" \
+                "#{Factory.string} " \
+                "#{Factory.string}"
+      exp = pattern.gsub("\\"){ "\\\\" }.gsub('%', "\\%").gsub('_', "\\_")
+      assert_equal exp, subject.escape_like_pattern(pattern)
+    end
+
+    should "allow using a custom escape char when escaping like patterns" do
+      escape_char = '#'
+      pattern = "#{Factory.string}%" \
+                "#{Factory.string}_" \
+                "#{Factory.string}\\" \
+                "#{Factory.string}#{escape_char}" \
+                "#{Factory.string} " \
+                "#{Factory.string}"
+      exp = pattern.gsub(escape_char, "#{escape_char}#{escape_char}")
+      exp = exp.gsub('%', "#{escape_char}%").gsub('_', "#{escape_char}_")
+      assert_equal exp, subject.escape_like_pattern(pattern, escape_char)
     end
 
     should "not implement the foreign key sql meths" do


### PR DESCRIPTION
This adds an `escape_like_pattern` helper method to adapters. This
can be used to escape wildcard characters in `LIKE` patterns so
users don't accidentally use wildcards. A typical use-case is
using a user supplied string to run a SQL query using `LIKE`. The
user may use characters like `%` and `_` which have special
meaning unless they are properly escaped. This helper can be used
to escape the user input so if a wildcard was used it is treated
literally. The helper also escapes the escape char which ensures
it is also treated literally. More than likely, a user intends the
characters to be treated literally and not have their special
meaning.

This is being added as an adapter helper method because its
possible that each adapter may have custom escape logic for like
patterns. The current set of adapters we support all use the same
logic and most likely, all SQL engines will be very similar for
like patterns. In the case we add more helper methods for escaping
adapter specific features then I would want all of our helpers to
be consistently implemented. Thus, I felt the best place to add the
helper method was to the adapter because it allowed the most
flexibility and allowed consistently implementing additional
helpers.

Note: Technically, a user unexpectedly being able to use a wildcard
character is SQL injection. It is most likely not nearly as
dangerous as most SQL injection issues but this also helps keep
users from getting access to data they aren't intended to be able
to access.

@kellyredding - Ready for review.