### PR TITLE
has slug: add option for skipping the uniqueness validation

### DIFF
--- a/lib/ardb/has_slug.rb
+++ b/lib/ardb/has_slug.rb
@@ -33,10 +33,13 @@ module Ardb
         # since the slug isn't written till an after callback we can't always
         # validate presence of it
         validates_presence_of(attribute, :on => :update)
-        validates_uniqueness_of(attribute, {
-          :case_sensitive => true,
-          :scope          => options[:unique_scope]
-        })
+
+        if options[:skip_unique_validation] != true
+          validates_uniqueness_of(attribute, {
+            :case_sensitive => true,
+            :scope          => options[:unique_scope]
+          })
+        end
 
         after_create :ardb_has_slug_generate_slugs
         after_update :ardb_has_slug_generate_slugs

--- a/test/unit/has_slug_tests.rb
+++ b/test/unit/has_slug_tests.rb
@@ -102,6 +102,16 @@ module Ardb::HasSlug
       assert_nil validation.options[:scope]
     end
 
+    should "not add a unique validation if skipping unique validation" do
+      subject.has_slug({
+        :source                 => @source_attribute,
+        :skip_unique_validation => true
+      })
+
+      validation = subject.validations.find{ |v| v.type == :uniqueness }
+      assert_nil validation
+    end
+
     should "allow customizing its validations using `has_slug`" do
       unique_scope = Factory.string.to_sym
       subject.has_slug({


### PR DESCRIPTION
This allows you to use the slugging behavior to set values but
not force those values to be unique.  This is more edge-case behavior
on a slug so we still validate uniqueness by default.  However, this
allows you to use slugging logic less-normalized data.

@jcredding ready for review.