### PR TITLE
Remove `db_file` as a config option

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -4,10 +4,14 @@
 # add the root dir to the load path
 $LOAD_PATH.unshift(File.expand_path("../..", __FILE__))
 
+TMP_PATH = File.expand_path("../../tmp", __FILE__)
+
 # require pry for debugging (`binding.pry`)
 require 'pry'
 require 'test/support/factory'
 
+# TODO - rework the tests so this isn't needed, requires removing coupling from
+# the main `Ardb` module
 ENV['ARDB_DB_FILE'] = 'tmp/testdb/config/db'
 require 'ardb'
 Ardb.init(false)

--- a/test/support/relative_require_test_db_file.rb
+++ b/test/support/relative_require_test_db_file.rb
@@ -1,0 +1,2 @@
+# this file is used to test that Ardb will relatively require a db file when
+# init

--- a/test/support/require_test_db_file.rb
+++ b/test/support/require_test_db_file.rb
@@ -1,0 +1,1 @@
+# this file is used to test that Ardb will require a db file when init

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -12,7 +12,6 @@ class Ardb::Config
     subject{ Ardb::Config }
 
     should have_namespace :db
-    should have_option  :db_file,   Pathname, :default => ENV['ARDB_DB_FILE']
     should have_option  :root_path, Pathname, :required => true
     should have_option  :logger, :required => true
     should have_options :migrations_path, :schema_path


### PR DESCRIPTION
This removes the `db_file` as a config option and adds the ability
to require it relative to the current working directory. This is
part of an effort to remove ns-options from the config and is also
part of updating Ardb to work with ruby 1.9+.

First, this removes the `db_file` as a config option and switches
to always using the env var. This is part of removing ns-options
because this reduces coupling to the `Config` and is one less
config option that has to be ported to a non ns-options
implementation. The `db_file` was confusing as a config option
because practically the `db_file` always needed to be configured
outside of the actual db file to be of any use. The design of
Ardb is that all the common configuration can be contained in the
db file except the db file configuration itself. This avoids the
confusion of having one option that should always be set outside of
the db file while all others are set in the db file.

Next, this also updates how the db file gets required to account
for changes in ruby 1.9+. Ruby 1.9+ doesn't automatically add the
current directory as a load path. This causes the default Ardb db
file `config/db` to not work unless the current directory is
manually added to the load paths. Typically this errors when
running the `ardb` bin because it can't find the db file and the
load paths can't be manually updated. To account for this, the db
file require will now fall back to trying to require the db file
via the current directory after it tries requiring it via the load
paths.

Finally, this updates the tests for `Ardb.init` to provide more
coverage and also adds some notes for future changes.

@kellyredding - Ready for review. I'm putting this in a feature branch so we can look at all the changes when I'm done and because there are backwards incompatible changes with the removal of ns-options.