### PR TITLE
Remove ns-options from `Config`

### DIFF
--- a/ardb.gemspec
+++ b/ardb.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency('activerecord',  ["~> 3.2"])
   gem.add_dependency('activesupport', ["~> 3.2"])
   gem.add_dependency('much-plugin',   ["~> 0.1.0"])
-  gem.add_dependency('ns-options',    ["~> 1.1.6"])
   gem.add_dependency('scmd',          ["~> 3.0.1"])
 
 end

--- a/lib/ardb/adapter/base.rb
+++ b/lib/ardb/adapter/base.rb
@@ -3,12 +3,12 @@ class Ardb::Adapter
 
   class Base
 
-    attr_reader :config_settings, :database
+    attr_reader :ar_connect_hash, :database
     attr_reader :schema_format, :ruby_schema_path, :sql_schema_path
 
     def initialize
-      @config_settings = Ardb.config.db_settings
-      @database = Ardb.config.db.database
+      @ar_connect_hash = Ardb.config.activerecord_connect_hash
+      @database = Ardb.config.database
       @schema_format = Ardb.config.schema_format
       schema_path = Ardb.config.schema_path
       @ruby_schema_path = "#{schema_path}.rb"

--- a/lib/ardb/adapter/postgresql.rb
+++ b/lib/ardb/adapter/postgresql.rb
@@ -5,22 +5,22 @@ class Ardb::Adapter
 
   class Postgresql < Base
 
-    def public_schema_settings
-      self.config_settings.merge({
+    def public_ar_connect_hash
+      self.ar_connect_hash.merge({
         'database'           => 'postgres',
         'schema_search_path' => 'public'
       })
     end
 
     def create_db
-      ActiveRecord::Base.establish_connection(self.public_schema_settings)
-      ActiveRecord::Base.connection.create_database(self.database, self.config_settings)
-      ActiveRecord::Base.establish_connection(self.config_settings)
+      ActiveRecord::Base.establish_connection(self.public_ar_connect_hash)
+      ActiveRecord::Base.connection.create_database(self.database, self.ar_connect_hash)
+      ActiveRecord::Base.establish_connection(self.ar_connect_hash)
     end
 
     def drop_db
       begin
-        ActiveRecord::Base.establish_connection(self.public_schema_settings)
+        ActiveRecord::Base.establish_connection(self.public_ar_connect_hash)
         ActiveRecord::Base.connection.tap do |conn|
           conn.execute "UPDATE pg_catalog.pg_database"\
                        " SET datallowconn=false WHERE datname='#{self.database}'"
@@ -74,10 +74,10 @@ class Ardb::Adapter
 
     def env_var_hash
       @env_var_hash ||= {
-        'PGHOST'     => self.config_settings['host'],
-        'PGPORT'     => self.config_settings['port'],
-        'PGUSER'     => self.config_settings['username'],
-        'PGPASSWORD' => self.config_settings['password']
+        'PGHOST'     => self.ar_connect_hash['host'],
+        'PGPORT'     => self.ar_connect_hash['port'],
+        'PGUSER'     => self.ar_connect_hash['username'],
+        'PGPASSWORD' => self.ar_connect_hash['password']
       }
     end
 

--- a/lib/ardb/adapter/sqlite.rb
+++ b/lib/ardb/adapter/sqlite.rb
@@ -19,7 +19,7 @@ class Ardb::Adapter
     def create_db
       validate!
       FileUtils.mkdir_p File.dirname(self.db_file_path)
-      ActiveRecord::Base.establish_connection(self.config_settings)
+      ActiveRecord::Base.establish_connection(self.ar_connect_hash)
     end
 
     def drop_db

--- a/lib/ardb/cli.rb
+++ b/lib/ardb/cli.rb
@@ -107,7 +107,7 @@ module Ardb
         @stderr = stderr || $stderr
 
         @clirb   = Ardb::CLIRB.new
-        @adapter = Ardb::Adapter.send(Ardb.config.db.adapter)
+        @adapter = Ardb::Adapter.send(Ardb.config.adapter)
       end
 
       def run
@@ -115,12 +115,12 @@ module Ardb
         begin
           Ardb.init
           @adapter.connect_db
-          @stdout.puts "connected to #{Ardb.config.db.adapter} db `#{Ardb.config.db.database}`"
+          @stdout.puts "connected to #{Ardb.config.adapter} db `#{Ardb.config.database}`"
         rescue StandardError => e
           @stderr.puts e
           @stderr.puts e.backtrace.join("\n")
-          @stderr.puts "error connecting to #{Ardb.config.db.database.inspect} database " \
-                       "with #{Ardb.config.db_settings.inspect}"
+          @stderr.puts "error connecting to #{Ardb.config.database.inspect} database " \
+                       "with #{Ardb.config.activerecord_connect_hash.inspect}"
           raise CommandExitError
         end
       end
@@ -142,17 +142,17 @@ module Ardb
         @stderr = stderr || $stderr
 
         @clirb   = Ardb::CLIRB.new
-        @adapter = Ardb::Adapter.send(Ardb.config.db.adapter)
+        @adapter = Ardb::Adapter.send(Ardb.config.adapter)
       end
 
       def run
         @clirb.parse!(@argv)
         begin
           @adapter.create_db
-          @stdout.puts "created #{Ardb.config.db.adapter} db `#{Ardb.config.db.database}`"
+          @stdout.puts "created #{Ardb.config.adapter} db `#{Ardb.config.database}`"
         rescue StandardError => e
           @stderr.puts e
-          @stderr.puts "error creating #{Ardb.config.db.database.inspect} database"
+          @stderr.puts "error creating #{Ardb.config.database.inspect} database"
           raise CommandExitError
         end
       end
@@ -174,17 +174,17 @@ module Ardb
         @stderr = stderr || $stderr
 
         @clirb   = Ardb::CLIRB.new
-        @adapter = Ardb::Adapter.send(Ardb.config.db.adapter)
+        @adapter = Ardb::Adapter.send(Ardb.config.adapter)
       end
 
       def run
         @clirb.parse!(@argv)
         begin
           @adapter.drop_db
-          @stdout.puts "dropped #{Ardb.config.db.adapter} db `#{Ardb.config.db.database}`"
+          @stdout.puts "dropped #{Ardb.config.adapter} db `#{Ardb.config.database}`"
         rescue StandardError => e
           @stderr.puts e
-          @stderr.puts "error dropping #{Ardb.config.db.database.inspect} database"
+          @stderr.puts "error dropping #{Ardb.config.database.inspect} database"
           raise CommandExitError
         end
       end
@@ -206,7 +206,7 @@ module Ardb
         @stderr = stderr || $stderr
 
         @clirb   = Ardb::CLIRB.new
-        @adapter = Ardb::Adapter.send(Ardb.config.db.adapter)
+        @adapter = Ardb::Adapter.send(Ardb.config.adapter)
       end
 
       def run
@@ -218,7 +218,7 @@ module Ardb
         rescue StandardError => e
           @stderr.puts e
           @stderr.puts e.backtrace.join("\n")
-          @stderr.puts "error migrating #{Ardb.config.db.database.inspect} database"
+          @stderr.puts "error migrating #{Ardb.config.database.inspect} database"
           raise CommandExitError
         end
       end

--- a/lib/ardb/migration_helpers.rb
+++ b/lib/ardb/migration_helpers.rb
@@ -32,7 +32,7 @@ module Ardb
         @to_table    = to_table.to_s
         @to_column   = (options[:to_column] || 'id').to_s
         @name        = (options[:name] || "fk_#{@from_table}_#{@from_column}").to_s
-        @adapter     = Ardb::Adapter.send(Ardb.config.db.adapter)
+        @adapter     = Ardb::Adapter.send(Ardb.config.adapter)
       end
 
       def add_sql

--- a/test/unit/adapter/base_tests.rb
+++ b/test/unit/adapter/base_tests.rb
@@ -10,7 +10,7 @@ class Ardb::Adapter::Base
     end
     subject{ @adapter }
 
-    should have_readers :config_settings, :database
+    should have_readers :ar_connect_hash, :database
     should have_readers :ruby_schema_path, :sql_schema_path
     should have_imeths :escape_like_pattern
     should have_imeths :foreign_key_add_sql, :foreign_key_drop_sql
@@ -19,11 +19,11 @@ class Ardb::Adapter::Base
     should have_imeths :dump_schema, :dump_ruby_schema, :dump_sql_schema
 
     should "know its config settings " do
-      assert_equal Ardb.config.db_settings, subject.config_settings
+      assert_equal Ardb.config.activerecord_connect_hash, subject.ar_connect_hash
     end
 
     should "know its database" do
-      assert_equal Ardb.config.db.database, subject.database
+      assert_equal Ardb.config.database, subject.database
     end
 
     should "know its schema paths" do

--- a/test/unit/adapter/postgresql_tests.rb
+++ b/test/unit/adapter/postgresql_tests.rb
@@ -12,14 +12,14 @@ class Ardb::Adapter::Postgresql
     end
     subject{ @adapter }
 
-    should have_imeths :public_schema_settings
+    should have_imeths :public_ar_connect_hash
 
     should "know its public schema connection settings" do
-      exp_settings = subject.config_settings.merge({
+      exp_settings = subject.public_ar_connect_hash.merge({
         'database' => 'postgres',
         'schema_search_path' => 'public'
       })
-      assert_equal exp_settings, subject.public_schema_settings
+      assert_equal exp_settings, subject.public_ar_connect_hash
     end
 
     should "know its foreign key add sql" do
@@ -41,10 +41,10 @@ class Ardb::Adapter::Postgresql
   class SQLSchemaTests < UnitTests
     setup do
       @env = {
-        'PGHOST'     => @adapter.config_settings['host'],
-        'PGPORT'     => @adapter.config_settings['port'],
-        'PGUSER'     => @adapter.config_settings['username'],
-        'PGPASSWORD' => @adapter.config_settings['password']
+        'PGHOST'     => @adapter.ar_connect_hash['host'],
+        'PGPORT'     => @adapter.ar_connect_hash['port'],
+        'PGUSER'     => @adapter.ar_connect_hash['username'],
+        'PGPASSWORD' => @adapter.ar_connect_hash['password']
       }
     end
 

--- a/test/unit/adapter/sqlite_tests.rb
+++ b/test/unit/adapter/sqlite_tests.rb
@@ -20,14 +20,14 @@ class Ardb::Adapter::Sqlite
     end
 
     should "know its db file path" do
-      exp = File.expand_path(Ardb.config.db.database, Ardb.config.root_path)
+      exp = File.expand_path(Ardb.config.database, Ardb.config.root_path)
       assert_equal exp, subject.db_file_path
 
-      orig_ardb_database = Ardb.config.db.database
-      Ardb.config.db.database = "#{TMP_PATH}/abs_sqlite_db_test"
+      orig_ardb_database = Ardb.config.database
+      Ardb.config.database = "#{TMP_PATH}/abs_sqlite_db_test"
       adapter = Ardb::Adapter::Sqlite.new
-      assert_equal Ardb.config.db.database, adapter.db_file_path
-      Ardb.config.db.database = orig_ardb_database
+      assert_equal Ardb.config.database, adapter.db_file_path
+      Ardb.config.database = orig_ardb_database
     end
 
     should "not implement the foreign key sql meths" do

--- a/test/unit/cli_tests.rb
+++ b/test/unit/cli_tests.rb
@@ -257,7 +257,7 @@ class Ardb::CLI
     desc "ConnectCommand"
     setup do
       @adapter_spy = Class.new{ include Ardb::AdapterSpy }.new
-      Assert.stub(Ardb::Adapter, Ardb.config.db.adapter.to_sym){ @adapter_spy }
+      Assert.stub(Ardb::Adapter, Ardb.config.adapter.to_sym){ @adapter_spy }
 
       @ardb_init_called = false
       Assert.stub(Ardb, :init){ @ardb_init_called = true }
@@ -287,7 +287,7 @@ class Ardb::CLI
       assert_true @ardb_init_called
       assert_true @adapter_spy.connect_db_called?
 
-      exp = "connected to #{Ardb.config.db.adapter} db `#{Ardb.config.db.database}`\n"
+      exp = "connected to #{Ardb.config.adapter} db `#{Ardb.config.database}`\n"
       assert_equal exp, @stdout.read
     end
 
@@ -302,8 +302,8 @@ class Ardb::CLI
       assert_includes err.to_s,                 err_output
       assert_includes err.backtrace.join("\n"), err_output
 
-      exp = "error connecting to #{Ardb.config.db.database.inspect} database " \
-            "with #{Ardb.config.db_settings.inspect}"
+      exp = "error connecting to #{Ardb.config.database.inspect} database " \
+            "with #{Ardb.config.activerecord_connect_hash.inspect}"
       assert_includes exp, err_output
     end
 
@@ -313,7 +313,7 @@ class Ardb::CLI
     desc "CreateCommand"
     setup do
       @adapter_spy = Class.new{ include Ardb::AdapterSpy }.new
-      Assert.stub(Ardb::Adapter, Ardb.config.db.adapter.to_sym){ @adapter_spy }
+      Assert.stub(Ardb::Adapter, Ardb.config.adapter.to_sym){ @adapter_spy }
 
       @command_class = CreateCommand
       @cmd = @command_class.new([], @stdout, @stderr)
@@ -338,7 +338,7 @@ class Ardb::CLI
       assert_equal [], subject.clirb.args
       assert_true @adapter_spy.create_db_called?
 
-      exp = "created #{Ardb.config.db.adapter} db `#{Ardb.config.db.database}`\n"
+      exp = "created #{Ardb.config.adapter} db `#{Ardb.config.database}`\n"
       assert_equal exp, @stdout.read
     end
 
@@ -350,7 +350,7 @@ class Ardb::CLI
       err_output = @stderr.read
 
       assert_includes err.to_s, err_output
-      exp = "error creating #{Ardb.config.db.database.inspect} database"
+      exp = "error creating #{Ardb.config.database.inspect} database"
       assert_includes exp, err_output
     end
 
@@ -360,7 +360,7 @@ class Ardb::CLI
     desc "DropCommand"
     setup do
       @adapter_spy = Class.new{ include Ardb::AdapterSpy }.new
-      Assert.stub(Ardb::Adapter, Ardb.config.db.adapter.to_sym){ @adapter_spy }
+      Assert.stub(Ardb::Adapter, Ardb.config.adapter.to_sym){ @adapter_spy }
 
       @command_class = DropCommand
       @cmd = @command_class.new([], @stdout, @stderr)
@@ -385,7 +385,7 @@ class Ardb::CLI
       assert_equal [], subject.clirb.args
       assert_true @adapter_spy.drop_db_called?
 
-      exp = "dropped #{Ardb.config.db.adapter} db `#{Ardb.config.db.database}`\n"
+      exp = "dropped #{Ardb.config.adapter} db `#{Ardb.config.database}`\n"
       assert_equal exp, @stdout.read
     end
 
@@ -397,7 +397,7 @@ class Ardb::CLI
       err_output = @stderr.read
 
       assert_includes err.to_s, err_output
-      exp = "error dropping #{Ardb.config.db.database.inspect} database"
+      exp = "error dropping #{Ardb.config.database.inspect} database"
       assert_includes exp, err_output
     end
 
@@ -407,7 +407,7 @@ class Ardb::CLI
     desc "MigrateCommand"
     setup do
       @adapter_spy = Class.new{ include Ardb::AdapterSpy }.new
-      Assert.stub(Ardb::Adapter, Ardb.config.db.adapter.to_sym){ @adapter_spy }
+      Assert.stub(Ardb::Adapter, Ardb.config.adapter.to_sym){ @adapter_spy }
 
       @ardb_init_called = false
       Assert.stub(Ardb, :init){ @ardb_init_called = true }
@@ -461,7 +461,7 @@ class Ardb::CLI
       assert_includes err.to_s,                 err_output
       assert_includes err.backtrace.join("\n"), err_output
 
-      exp = "error migrating #{Ardb.config.db.database.inspect} database"
+      exp = "error migrating #{Ardb.config.database.inspect} database"
       assert_includes exp, err_output
     end
 

--- a/test/unit/migration_helpers_tests.rb
+++ b/test/unit/migration_helpers_tests.rb
@@ -38,7 +38,7 @@ module Ardb::MigrationHelpers
     end
 
     should "use Ardb's config db adapter" do
-      exp_adapter = Ardb::Adapter.send(Ardb.config.db.adapter)
+      exp_adapter = Ardb::Adapter.send(Ardb.config.adapter)
       assert_equal exp_adapter, subject.adapter
     end
 

--- a/tmp/testdb/config/db.rb
+++ b/tmp/testdb/config/db.rb
@@ -5,9 +5,8 @@ TESTDB_PATH = File.expand_path('../..', __FILE__)
 
 Ardb.configure do |c|
   c.root_path = TESTDB_PATH
-  c.logger = Logger.new($stdout)
+  c.logger    = Logger.new($stdout)
 
-  c.db.adapter  'postgresql'
-  c.db.database 'ardbtest'
-
+  c.adapter  = 'postgresql'
+  c.database = 'ardbtest'
 end


### PR DESCRIPTION
This removes ns-options from the `Config` class and simplifies the
`Config`. This is being done for a number of reasons. Ardb config
doesn't need to leverage all of the functionality of ns-options so
its overkill to use it for its config. This also simplifies the
upgrade path to a newer ruby because ns-options is not currently
compatible with it. Also by removing a dependency this decouples
and makes the maintenance of ardb easier.

This changes the `Config` class to no longer include ns-options
and changes its options to simple attribute reader/writers and
no longer be accessed via a `db` namespace. The activerecord
attrs are simple accessors and no special processing or type
casting is done. This allows users to have essentially direct
access to the activerecord options. This lets them configure
activerecord however they normally would.

The logger and schema format options were also updated to be
simple accessors. The logger is now defaulted to a stdout ruby
logger and is no longer required. This allows setting the
activerecord logger to `nil` to disable logging if desired. The
schema format is still defaulted to ruby and attempts to cast any
new value to a symbol.

Next, this renames the `db_settings` method to
`activerecord_connect_hash`. This is to make it clear what this
method is intended for and how it should be used. This helps to
avoid coupling to this method which will allow us to change it
freely to whatever activerecord wants.

This also adds a `validate!` method to the `Config` and removes
it from the `Ardb` module. ns-options previously provided the
validation via its `required_set?` method. The `validate!` method
checks if its adapter and database are set, which is what was
previously done by ns-options. In addition, the schema format is
now validated to make sure it matches a known value which avoids
strange errors using ardb features.

@kellyredding - Ready for review.