### PR TITLE
Simplify and expand `AdapterSpy`, use in migration helpers tests

### DIFF
--- a/lib/ardb/adapter_spy.rb
+++ b/lib/ardb/adapter_spy.rb
@@ -1,112 +1,92 @@
-require 'much-plugin'
+require 'ardb'
+require 'ardb/adapter/base'
 
 module Ardb
 
-  module AdapterSpy
-    include MuchPlugin
+  class AdapterSpy < Ardb::Adapter::Base
 
-    def self.new(&block)
-      block ||= proc{ }
-      record_spy = Class.new{ include Ardb::AdapterSpy }
-      record_spy.class_eval(&block)
-      record_spy
+    attr_accessor :drop_tables_called_count
+    attr_accessor :dump_schema_called_count, :load_schema_called_count
+    attr_accessor :drop_db_called_count, :create_db_called_count
+    attr_accessor :connect_db_called_count, :migrate_db_called_count
+
+    def initialize
+      super
+      @drop_tables_called_count = 0
+      @dump_schema_called_count = 0
+      @load_schema_called_count = 0
+      @drop_db_called_count     = 0
+      @create_db_called_count   = 0
+      @connect_db_called_count  = 0
+      @migrate_db_called_count  = 0
     end
 
-    plugin_included do
-      include InstanceMethods
+    def create_db_called?
+      self.create_db_called_count > 0
     end
 
-    module InstanceMethods
+    def drop_db_called?
+      self.drop_db_called_count > 0
+    end
 
-      attr_accessor :drop_tables_called_count
-      attr_accessor :dump_schema_called_count, :load_schema_called_count
-      attr_accessor :drop_db_called_count, :create_db_called_count
-      attr_accessor :connect_db_called_count, :migrate_db_called_count
+    def drop_tables_called?
+      self.drop_tables_called_count > 0
+    end
 
-      def drop_tables_called_count
-        @drop_tables_called_count ||= 0
-      end
+    def connect_db_called?
+      self.connect_db_called_count > 0
+    end
 
-      def drop_tables_called?
-        self.drop_tables_called_count > 0
-      end
+    def migrate_db_called?
+      self.migrate_db_called_count > 0
+    end
 
-      def drop_tables(*args, &block)
-        self.drop_tables_called_count += 1
-      end
+    def load_schema_called?
+      self.load_schema_called_count > 0
+    end
 
-      def dump_schema_called_count
-        @dump_schema_called_count ||= 0
-      end
+    def dump_schema_called?
+      self.dump_schema_called_count > 0
+    end
 
-      def dump_schema_called?
-        self.dump_schema_called_count > 0
-      end
+    # Overwritten `Adapter::Base` methods
 
-      def dump_schema(*args, &block)
-        self.dump_schema_called_count += 1
-      end
+    def foreign_key_add_sql
+      "FAKE ADD FOREIGN KEY SQL :from_table :from_column " \
+      ":to_table :to_column :name"
+    end
 
-      def load_schema_called_count
-        @load_schema_called_count ||= 0
-      end
+    def foreign_key_drop_sql
+      "FAKE DROP FOREIGN KEY SQL :from_table :from_column " \
+      ":to_table :to_column :name"
+    end
 
-      def load_schema_called?
-        self.load_schema_called_count > 0
-      end
+    def create_db(*args, &block)
+      self.create_db_called_count += 1
+    end
 
-      def load_schema(*args, &block)
-        self.load_schema_called_count += 1
-      end
+    def drop_db(*args, &block)
+      self.drop_db_called_count += 1
+    end
 
-      def drop_db_called_count
-        @drop_db_called_count ||= 0
-      end
+    def drop_tables(*args, &block)
+      self.drop_tables_called_count += 1
+    end
 
-      def drop_db_called?
-        self.drop_db_called_count > 0
-      end
+    def connect_db(*args, &block)
+      self.connect_db_called_count += 1
+    end
 
-      def drop_db(*args, &block)
-        self.drop_db_called_count += 1
-      end
+    def migrate_db(*args, &block)
+      self.migrate_db_called_count += 1
+    end
 
-      def create_db_called_count
-        @create_db_called_count ||= 0
-      end
+    def load_schema(*args, &block)
+      self.load_schema_called_count += 1
+    end
 
-      def create_db_called?
-        self.create_db_called_count > 0
-      end
-
-      def create_db(*args, &block)
-        self.create_db_called_count += 1
-      end
-
-      def connect_db_called_count
-        @connect_db_called_count ||= 0
-      end
-
-      def connect_db_called?
-        self.connect_db_called_count > 0
-      end
-
-      def connect_db(*args, &block)
-        self.connect_db_called_count += 1
-      end
-
-      def migrate_db_called_count
-        @migrate_db_called_count ||= 0
-      end
-
-      def migrate_db_called?
-        self.migrate_db_called_count > 0
-      end
-
-      def migrate_db(*args, &block)
-        self.migrate_db_called_count += 1
-      end
-
+    def dump_schema(*args, &block)
+      self.dump_schema_called_count += 1
     end
 
   end

--- a/test/unit/adapter_spy_tests.rb
+++ b/test/unit/adapter_spy_tests.rb
@@ -1,52 +1,84 @@
 require 'assert'
 require 'ardb/adapter_spy'
 
-require 'much-plugin'
-
-module Ardb::AdapterSpy
+class Ardb::AdapterSpy
 
   class UnitTests < Assert::Context
     desc "Ardb::AdapterSpy"
     setup do
-      @adapter = MyAdapter.new
+      @adapter_spy_class = Ardb::AdapterSpy
     end
-    subject{ @adapter }
+    subject{ @adapter_spy_class }
+
+    should "be a kind of ardb adapter" do
+      assert subject < Ardb::Adapter::Base
+    end
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @adapter_spy = @adapter_spy_class.new
+    end
+    subject{ @adapter_spy }
 
     should have_accessors :drop_tables_called_count
     should have_accessors :dump_schema_called_count, :load_schema_called_count
     should have_accessors :drop_db_called_count, :create_db_called_count
     should have_accessors :connect_db_called_count, :migrate_db_called_count
-    should have_imeths :drop_tables_called?, :drop_tables
-    should have_imeths :dump_schema_called?, :dump_schema
-    should have_imeths :load_schema_called?, :load_schema
-    should have_imeths :drop_db_called?, :drop_db
-    should have_imeths :create_db_called?, :create_db
-    should have_imeths :connect_db_called?, :connect_db
-    should have_imeths :migrate_db_called?, :migrate_db
-
-    should "use much-plugin" do
-      assert_includes MuchPlugin, Ardb::AdapterSpy
-    end
-
-    should "included the adapter spy instance methods" do
-      assert_includes Ardb::AdapterSpy::InstanceMethods, subject.class
-    end
+    should have_imeths :foreign_key_add_sql, :foreign_key_drop_sql
+    should have_imeths :create_db_called?, :drop_db_called?, :drop_tables_called?
+    should have_imeths :connect_db_called?, :migrate_db_called?
+    should have_imeths :dump_schema_called?, :load_schema_called?
+    should have_imeths :create_db, :drop_db, :drop_tables
+    should have_imeths :connect_db, :migrate_db
+    should have_imeths :dump_schema, :load_schema
 
     should "default all call counts to zero" do
-      assert_equal 0, subject.drop_tables_called_count
-      assert_equal 0, subject.dump_schema_called_count
-      assert_equal 0, subject.load_schema_called_count
-      assert_equal 0, subject.drop_db_called_count
       assert_equal 0, subject.create_db_called_count
+      assert_equal 0, subject.drop_db_called_count
+      assert_equal 0, subject.drop_tables_called_count
       assert_equal 0, subject.connect_db_called_count
       assert_equal 0, subject.migrate_db_called_count
+      assert_equal 0, subject.load_schema_called_count
+      assert_equal 0, subject.dump_schema_called_count
+    end
+
+    should "know its add and drop foreign key sql" do
+      exp = "FAKE ADD FOREIGN KEY SQL :from_table :from_column " \
+            ":to_table :to_column :name"
+      assert_equal exp, subject.foreign_key_add_sql
+      exp = "FAKE DROP FOREIGN KEY SQL :from_table :from_column " \
+            ":to_table :to_column :name"
+      assert_equal exp, subject.foreign_key_drop_sql
     end
 
     should "know if and how many times a method is called" do
+      assert_equal false, subject.create_db_called?
+      subject.create_db
+      assert_equal 1, subject.create_db_called_count
+      assert_equal true, subject.create_db_called?
+
+      assert_equal false, subject.drop_db_called?
+      subject.drop_db
+      assert_equal 1, subject.drop_db_called_count
+      assert_equal true, subject.drop_db_called?
+
       assert_equal false, subject.drop_tables_called?
       subject.drop_tables
       assert_equal 1, subject.drop_tables_called_count
       assert_equal true, subject.drop_tables_called?
+
+      assert_equal false, subject.connect_db_called?
+      subject.connect_db
+      assert_equal 1, subject.connect_db_called_count
+      assert_equal true, subject.connect_db_called?
+
+      assert_equal false, subject.migrate_db_called?
+      subject.migrate_db
+      assert_equal 1, subject.migrate_db_called_count
+      assert_equal true, subject.migrate_db_called?
 
       assert_equal false, subject.dump_schema_called?
       subject.dump_schema
@@ -57,50 +89,8 @@ module Ardb::AdapterSpy
       subject.load_schema
       assert_equal 1, subject.load_schema_called_count
       assert_equal true, subject.load_schema_called?
-
-      assert_equal false, subject.drop_db_called?
-      subject.drop_db
-      assert_equal 1, subject.drop_db_called_count
-      assert_equal true, subject.drop_db_called?
-
-      assert_equal false, subject.create_db_called?
-      subject.create_db
-      assert_equal 1, subject.create_db_called_count
-      assert_equal true, subject.create_db_called?
-
-      assert_equal false, subject.migrate_db_called?
-      subject.migrate_db
-      assert_equal 1, subject.migrate_db_called_count
-      assert_equal true, subject.migrate_db_called?
-
-      assert_equal false, subject.connect_db_called?
-      subject.connect_db
-      assert_equal 1, subject.connect_db_called_count
-      assert_equal true, subject.connect_db_called?
     end
 
-  end
-
-  class NewMethTests < UnitTests
-    desc "`new` method"
-    setup do
-      @adapter_spy_class = Ardb::AdapterSpy.new do
-        attr_accessor :name
-      end
-      @adapter = @adapter_spy_class.new
-    end
-    subject{ @adapter }
-
-    should "build a new spy class and use any custom definition" do
-      assert_includes Ardb::AdapterSpy, subject.class
-      assert subject.respond_to? :name
-      assert subject.respond_to? :name=
-    end
-
-  end
-
-  class MyAdapter
-    include Ardb::AdapterSpy
   end
 
 end

--- a/test/unit/cli_tests.rb
+++ b/test/unit/cli_tests.rb
@@ -256,7 +256,7 @@ class Ardb::CLI
   class ConnectCommandTests < UnitTests
     desc "ConnectCommand"
     setup do
-      @adapter_spy = Class.new{ include Ardb::AdapterSpy }.new
+      @adapter_spy = Ardb::AdapterSpy.new
       Assert.stub(Ardb::Adapter, Ardb.config.adapter.to_sym){ @adapter_spy }
 
       @ardb_init_called = false
@@ -312,7 +312,7 @@ class Ardb::CLI
   class CreateCommandTests < UnitTests
     desc "CreateCommand"
     setup do
-      @adapter_spy = Class.new{ include Ardb::AdapterSpy }.new
+      @adapter_spy = Ardb::AdapterSpy.new
       Assert.stub(Ardb::Adapter, Ardb.config.adapter.to_sym){ @adapter_spy }
 
       @command_class = CreateCommand
@@ -359,7 +359,7 @@ class Ardb::CLI
   class DropCommandTests < UnitTests
     desc "DropCommand"
     setup do
-      @adapter_spy = Class.new{ include Ardb::AdapterSpy }.new
+      @adapter_spy = Ardb::AdapterSpy.new
       Assert.stub(Ardb::Adapter, Ardb.config.adapter.to_sym){ @adapter_spy }
 
       @command_class = DropCommand
@@ -406,7 +406,7 @@ class Ardb::CLI
   class MigrateCommandTests < UnitTests
     desc "MigrateCommand"
     setup do
-      @adapter_spy = Class.new{ include Ardb::AdapterSpy }.new
+      @adapter_spy = Ardb::AdapterSpy.new
       Assert.stub(Ardb::Adapter, Ardb.config.adapter.to_sym){ @adapter_spy }
 
       @ardb_init_called = false

--- a/test/unit/migration_helpers_tests.rb
+++ b/test/unit/migration_helpers_tests.rb
@@ -1,6 +1,8 @@
 require 'assert'
 require 'ardb/migration_helpers'
 
+require 'ardb/adapter_spy'
+
 module Ardb::MigrationHelpers
 
   class UnitTests < Assert::Context
@@ -14,6 +16,11 @@ module Ardb::MigrationHelpers
   class ForeignKeyTests < UnitTests
     desc "ForeignKey handler"
     setup do
+      @adapter_spy = nil
+      Assert.stub(Ardb::Adapter, Ardb.config.adapter.to_sym) do
+        @adapter_spy = Ardb::AdapterSpy.new
+      end
+
       @fk = ForeignKey.new('fromtbl', 'fromcol', 'totbl')
     end
     subject{ @fk }
@@ -37,21 +44,19 @@ module Ardb::MigrationHelpers
       assert_equal exp_name, subject.name
     end
 
-    should "use Ardb's config db adapter" do
-      exp_adapter = Ardb::Adapter.send(Ardb.config.adapter)
-      assert_equal exp_adapter, subject.adapter
+    should "know its adapter" do
+      assert_not_nil @adapter_spy
+      assert_equal @adapter_spy, subject.adapter
     end
 
     should "generate appropriate foreign key sql" do
-      exp_add_sql = "ALTER TABLE fromtbl"\
-                    " ADD CONSTRAINT fk_fromtbl_fromcol"\
-                    " FOREIGN KEY (fromcol)"\
-                    " REFERENCES totbl (id)"
-      assert_equal exp_add_sql, subject.add_sql
+      exp = "FAKE ADD FOREIGN KEY SQL fromtbl fromcol " \
+            "totbl id fk_fromtbl_fromcol"
+      assert_equal exp, subject.add_sql
 
-      exp_drop_sql = "ALTER TABLE fromtbl"\
-                     " DROP CONSTRAINT fk_fromtbl_fromcol"
-      assert_equal exp_drop_sql, subject.drop_sql
+      exp = "FAKE DROP FOREIGN KEY SQL fromtbl fromcol " \
+            "totbl id fk_fromtbl_fromcol"
+      assert_equal exp, subject.drop_sql
     end
 
   end

--- a/test/unit/test_helpers_tests.rb
+++ b/test/unit/test_helpers_tests.rb
@@ -18,9 +18,8 @@ module Ardb::TestHelpers
 
   class UsageTests < UnitTests
     setup do
-      @adapter_spy_class = Ardb::AdapterSpy.new
       @orig_ardb_adapter = Ardb.adapter
-      Ardb::Adapter.current = @adapter_spy = @adapter_spy_class.new
+      Ardb::Adapter.current = @adapter_spy = Ardb::AdapterSpy.new
     end
     teardown do
       Ardb::Adapter.current = @orig_ardb_adapter


### PR DESCRIPTION
This simplifies and expands the `AdapterSpy`. This was noticed
while working on decoupling adapters from the global `Ardb.config`.
This simplifies the `AdapterSpy` to just be an adapter (inherit
from the base adapter) that overwrites the adapter methods to be
spy methods. This also expands it to have fake foreign key sql
methods which allows using it in the migration helpers tests.

The `AdapterSpy` now inherits from `Adapters::Base`, ensuring it
has the same interface as a real adapter. It still overwrites the
adapter methods to spy on them as it did before. This removes it
as a module and dynamic class generator. In hindsight, these didn't
make sense as features. None of the tests used its ability to
add a dynamic interface to an adapter class. Furthermore, it
doesn't make good sense for a tool that works with any adapter to
expect an interface that isn't common to all adapters. I also
checked in code that uses Ardb and didn't find the `AdapterSpy`
being used. This matches up with the commit messages relating to
it which mention it being added for the test helpers tests and then
later being used for the cli tests. This also includes a minor
cleanup to the adapter spy to orders its methods so they match
the order in the base adapter.

This also changes the migration helper tests to use the adapter
spy instead of relying on the `Ardb.config` to be configured for a
specific adapter. Previously, the `Ardb.config.adapter` needed to
be configured to use postgres so that the foreign key sql tests
would pass. The test suite is still configuring the adapter to be
postgres for all unit tests because other tests still depend on it
but it will be removed in a future commit.

@kellyredding - Ready for review.