### PR TITLE
Add shim that adds support for postgres json columns to activerecord

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,12 @@ source "https://rubygems.org"
 
 gemspec
 
-gem 'pry',  "~> 0.9.0"
+gem 'pg',  "~> 0.17.1"
+gem 'pry', "~> 0.9.0"
 
 # Lock down gem versions because they require a newer version of ruby
 gem 'i18n', "< 0.7"
 
+platform :ruby_18 do
+  gem 'json', '~> 1.8'
+end

--- a/ardb.gemspec
+++ b/ardb.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency("assert", ["~> 2.15.1"])
+  gem.add_development_dependency("assert", ["~> 2.16.0"])
 
   gem.add_dependency('activerecord',  ["~> 3.2"])
   gem.add_dependency('activesupport', ["~> 3.2"])

--- a/lib/ardb/pg_json.rb
+++ b/lib/ardb/pg_json.rb
@@ -1,0 +1,90 @@
+require 'active_record'
+require 'active_support'
+
+# Allow ActiveRecord to work with PostgreSQL json/jsonb fields, which aren't
+# supported with ActiveRecord 3.2
+# https://github.com/romanbsd/activerecord-postgres-json/blob/master/lib/activerecord-postgres-json/activerecord.rb
+require 'active_record/connection_adapters/postgresql_adapter'
+
+module ActiveRecord
+  module ConnectionAdapters
+    PostgreSQLAdapter::NATIVE_DATABASE_TYPES[:json]  = { :name => 'json' }
+    PostgreSQLAdapter::NATIVE_DATABASE_TYPES[:jsonb] = { :name => 'jsonb' }
+
+    class PostgreSQLColumn < Column
+      # Adds the json type for the column.
+      def simplified_type_with_json(field_type)
+        case field_type
+        when 'json'
+          :json
+        when 'jsonb'
+          :jsonb
+        else
+          simplified_type_without_json(field_type)
+        end
+      end
+
+      alias_method_chain :simplified_type, :json
+
+      class << self
+        def extract_value_from_default_with_json(default)
+          case default
+          when "'{}'::json", "'{}'::jsonb"
+            '{}'
+          when "'[]'::json", "'[]'::jsonb"
+            '[]'
+          else
+            extract_value_from_default_without_json(default)
+          end
+        end
+
+        alias_method_chain :extract_value_from_default, :json
+      end
+
+    end
+
+    class TableDefinition
+      # Adds json type for migrations. So you can add columns to a table like:
+      #   create_table :people do |t|
+      #     ...
+      #     t.json :info
+      #     ...
+      #   end
+      def json(*args)
+        options = args.extract_options!
+        column_names = args
+        column_names.each { |name| column(name, 'json', options) }
+      end
+
+      def jsonb(*args)
+        options = args.extract_options!
+        column_names = args
+        column_names.each { |name| column(name, 'jsonb', options) }
+      end
+
+    end
+
+    class Table
+      # Adds json type for migrations. So you can add columns to a table like:
+      #   change_table :people do |t|
+      #     ...
+      #     t.json :info
+      #     ...
+      #   end
+      def json(*args)
+        options = args.extract_options!
+        column_names = args
+        column_names.each { |name| column(name, 'json', options) }
+      end
+
+      def jsonb(*args)
+        options = args.extract_options!
+        column_names = args
+        column_names.each { |name| column(name, 'jsonb', options) }
+      end
+
+    end
+
+  end
+
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -4,7 +4,12 @@
 # add the root dir to the load path
 $LOAD_PATH.unshift(File.expand_path("../..", __FILE__))
 
-TMP_PATH = File.expand_path("../../tmp", __FILE__)
+TEST_SUPPORT_PATH = File.expand_path("../support", __FILE__)
+TMP_PATH          = File.expand_path("../../tmp", __FILE__)
+
+require 'logger'
+log_path = File.expand_path("../../log/test.log", __FILE__)
+TEST_LOGGER = Logger.new(File.open(log_path, 'w'))
 
 # require pry for debugging (`binding.pry`)
 require 'pry'

--- a/test/support/postgresql/pg_json_migrations/20160519133432_create_pg_json_migrate_test.rb
+++ b/test/support/postgresql/pg_json_migrations/20160519133432_create_pg_json_migrate_test.rb
@@ -1,0 +1,13 @@
+require 'ardb/migration_helpers'
+
+class CreatePgJsonMigrateTest < ActiveRecord::Migration
+  include Ardb::MigrationHelpers
+
+  def change
+    create_table :pg_json_test_records do |t|
+      t.json  :json_attribute
+    end
+    add_column :pg_json_test_records, :jsonb_attribute, :jsonb
+  end
+
+end

--- a/test/support/postgresql/schema.rb
+++ b/test/support/postgresql/schema.rb
@@ -1,0 +1,3 @@
+ActiveRecord::Schema.define(:version => 0) do
+
+end

--- a/test/support/postgresql/setup_test_db.rb
+++ b/test/support/postgresql/setup_test_db.rb
@@ -1,0 +1,50 @@
+require 'assert'
+require 'ardb'
+
+class PostgresqlDbTests < Assert::Context
+  setup do
+    @orig_env_ardb_db_file    = ENV['ARDB_DB_FILE']
+    ActiveRecord::Base.logger = @orig_ar_loggerF
+
+    # no-op, we're manually configuring ardb so we don't need this to do anything
+    ENV['ARDB_DB_FILE'] = File.join(TEST_SUPPORT_PATH, 'require_test_db_file')
+
+    @ardb_config = Ardb::Config.new.tap do |c|
+      c.adapter      = 'postgresql'
+      c.database     = 'redding_ardb_test'
+      c.encoding     = 'unicode'
+      c.min_messages = 'WARNING'
+
+      c.logger          = TEST_LOGGER
+      c.root_path       = File.join(TEST_SUPPORT_PATH, 'postgresql')
+      c.migrations_path = 'migrations'
+      c.schema_path     = 'schema'
+      c.schema_format   = :ruby
+    end
+    Assert.stub(Ardb, :config){ @ardb_config }
+
+    Ardb.init
+
+    Ardb.adapter.drop_db
+    Ardb.adapter.create_db
+    Ardb.adapter.load_schema
+  end
+  teardown do
+    ActiveRecord::Base.logger = @orig_ar_logger
+    ENV['ARDB_DB_FILE']       = @orig_env_ardb_db_file
+  end
+
+  private
+
+  # useful when testing creating/dropping/migrating DBs
+  def silence_stdout
+    current_stdout = $stdout.dup
+    $stdout = File.new('/dev/null', 'w')
+    begin
+      yield
+    ensure
+      $stdout = current_stdout
+    end
+  end
+
+end

--- a/test/system/pg_json_tests.rb
+++ b/test/system/pg_json_tests.rb
@@ -1,0 +1,85 @@
+require 'assert'
+require 'ardb/pg_json'
+
+require 'json'
+require 'test/support/postgresql/setup_test_db'
+
+module Ardb; end
+module Ardb::PgJson
+
+  class SystemTests < PostgresqlDbTests
+    desc "Ardb postgresql json shim"
+    setup do
+      @ardb_config.migrations_path = 'pg_json_migrations'
+    end
+
+    should "add support for postgresql json columns to migrations" do
+      # this should migrate the db, adding a record that has json/jsonb columns
+      assert_nothing_raised do
+        silence_stdout{ Ardb.adapter.migrate_db }
+      end
+
+      results = ActiveRecord::Base.connection.execute(
+        "SELECT column_name, data_type " \
+        "FROM INFORMATION_SCHEMA.COLUMNS " \
+        "WHERE table_name = 'pg_json_test_records'"
+      ).to_a
+      exp = {
+        'column_name' => 'json_attribute',
+        'data_type'   => 'json',
+      }
+      assert_includes exp, results
+      exp = {
+        'column_name' => 'jsonb_attribute',
+        'data_type'   => 'jsonb'
+      }
+      assert_includes exp, results
+    end
+
+  end
+
+  class WithMigratedTableTests < SystemTests
+    setup do
+      silence_stdout{ Ardb.adapter.migrate_db }
+      @record_class = Class.new(ActiveRecord::Base) do
+        self.table_name = 'pg_json_test_records'
+      end
+    end
+
+    should "add support for postgresql 'json' attributes on records" do
+      values = [Factory.string, Factory.integer, nil]
+
+      record = @record_class.new
+      assert_nil record.json_attribute
+      assert_nil record.jsonb_attribute
+
+      hash = Factory.integer(3).times.inject({}) do |h, n|
+        h.merge!(Factory.string => values.choice)
+      end
+      record.json_attribute  = JSON.dump(hash)
+      record.jsonb_attribute = JSON.dump(hash)
+      assert_nothing_raised{ record.save! }
+      record.reload
+      assert_equal hash, JSON.load(record.json_attribute)
+      assert_equal hash, JSON.load(record.jsonb_attribute)
+
+      array = Factory.integer(3).times.map{ values.choice }
+      record.json_attribute  = JSON.dump(array)
+      record.jsonb_attribute = JSON.dump(array)
+      assert_nothing_raised{ record.save! }
+      record.reload
+      assert_equal array, JSON.load(record.json_attribute)
+      assert_equal array, JSON.load(record.jsonb_attribute)
+
+      value = values.choice
+      record.json_attribute  = JSON.dump(value)
+      record.jsonb_attribute = JSON.dump(value)
+      assert_nothing_raised{ record.save! }
+      record.reload
+      assert_equal value, JSON.load(record.json_attribute)
+      assert_equal value, JSON.load(record.jsonb_attribute)
+    end
+
+  end
+
+end

--- a/test/unit/adapter/base_tests.rb
+++ b/test/unit/adapter/base_tests.rb
@@ -102,6 +102,9 @@ class Ardb::Adapter::Base
   class MigrateDbTests < UnitTests
     desc "`migrate_db`"
     setup do
+      @orig_migrate_version_env_var = ENV['MIGRATE_VERSION']
+      @orig_migrate_query_env_var   = ENV['MIGRATE_QUIET']
+
       ENV["MIGRATE_VERSION"] = Factory.integer.to_s if Factory.boolean
       ENV["MIGRATE_QUIET"]   = Factory.boolean.to_s if Factory.boolean
 
@@ -111,6 +114,10 @@ class Ardb::Adapter::Base
       end
 
       @adapter.migrate_db
+    end
+    teardown do
+      ENV['MIGRATE_VERSION'] = @orig_migrate_version_env_var
+      ENV['MIGRATE_QUIET']   = @orig_migrate_query_env_var
     end
 
     should "add the ardb migration helper recorder to activerecord's command recorder" do

--- a/test/unit/ardb_tests.rb
+++ b/test/unit/ardb_tests.rb
@@ -54,7 +54,7 @@ module Ardb
         @ardb_adapter = Ardb::AdapterSpy.new(*args)
       end
 
-      ENV['ARDB_DB_FILE'] = 'test/support/require_test_db_file'
+      ENV['ARDB_DB_FILE']   = 'test/support/require_test_db_file'
       @ardb_config.adapter  = Adapter::VALID_ADAPTERS.choice
       @ardb_config.database = Factory.string
 

--- a/test/unit/pg_json_tests.rb
+++ b/test/unit/pg_json_tests.rb
@@ -1,0 +1,39 @@
+require 'assert'
+require 'ardb/pg_json'
+
+module Ardb; end
+module Ardb::PgJson
+
+  class UnitTests < Assert::Context
+    desc "Ardb postgresql json shim"
+    setup do
+      @connection_adapters = ActiveRecord::ConnectionAdapters
+    end
+    subject{ @connection_adapters }
+
+    should "update active record postgres adapter to support json columns" do
+      adapter_class = subject::PostgreSQLAdapter
+      exp = { :name => 'json' }
+      assert_equal exp, adapter_class::NATIVE_DATABASE_TYPES[:json]
+      exp = { :name => 'jsonb' }
+      assert_equal exp, adapter_class::NATIVE_DATABASE_TYPES[:jsonb]
+    end
+
+    should "update active record postgres column to support json columns" do
+      column_class = subject::PostgreSQLColumn
+      default = Factory.boolean ? "'{}'::json" : "'{}'::jsonb"
+      assert_equal '{}', column_class.extract_value_from_default(default)
+      default = Factory.boolean ? "'[]'::json" : "'[]'::jsonb"
+      assert_equal '[]', column_class.extract_value_from_default(default)
+
+      column = column_class.new(Factory.string, Factory.string)
+      assert_equal :json,  column.send(:simplified_type, 'json')
+      assert_equal :jsonb, column.send(:simplified_type, 'jsonb')
+    end
+
+    # Note: The rest of the postgresql json shim logic is tested in the pg json
+    # system tests
+
+  end
+
+end


### PR DESCRIPTION
This adds a helper file `ardb/pg_json` that can be required to
modify activerecord so that it will support postgres json columns.
This is needed for activerecord 3.2 because it doesn't support
json columns by default. This isn't required by default and should
only be used when using ardb with a postgres adapter.

This also sets up having adapter specific system tests. These were
needed to properly test the shim and make sure it modified
activerecord as expected. This only sets up postgres system tests
but this could be expanded to the other adapters and used to test
their methods. The pg json migrations are separated from regular
migrations because pg json logic is explicitly tested and there
isn't any reason for the pg json or (if there were any) postgres
system tests to have to run each others migrations.

This is a similar pattern to how an application that uses Ardb is
tested but has a few differences. Ardb tests need to test multiple
adapters and its global state. Because of this, Ardb resets the DB
before each db test. In an application, the db can usually be reset
once at the beginning of the all of the tests because the Ardb
configuration and adapter don't change while running the test
suite. Ardb also has to test creating, migrating and dropping
databases which is not someting that would normally be done in an
application's test suite. All of this makes it so the DB needs to
be reset before each test. Since Ardb should have a relatively
small number of system tests the performance overhead of doing this
is not as painful as it would be in a much larger test suite for
an application.

@kellyredding - Ready for review.