### PR TITLE
Switch to using `sample` instead of `choice`, backfill for 1.8.7

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -14,3 +14,12 @@ TEST_LOGGER = Logger.new(File.open(log_path, 'w'))
 # require pry for debugging (`binding.pry`)
 require 'pry'
 require 'test/support/factory'
+
+# 1.8.7 backfills
+
+# Array#sample
+if !(a = Array.new).respond_to?(:sample) && a.respond_to?(:choice)
+  class Array
+    alias_method :sample, :choice
+  end
+end

--- a/test/system/pg_json_tests.rb
+++ b/test/system/pg_json_tests.rb
@@ -54,7 +54,7 @@ module Ardb::PgJson
       assert_nil record.jsonb_attribute
 
       hash = Factory.integer(3).times.inject({}) do |h, n|
-        h.merge!(Factory.string => values.choice)
+        h.merge!(Factory.string => values.sample)
       end
       record.json_attribute  = JSON.dump(hash)
       record.jsonb_attribute = JSON.dump(hash)
@@ -63,7 +63,7 @@ module Ardb::PgJson
       assert_equal hash, JSON.load(record.json_attribute)
       assert_equal hash, JSON.load(record.jsonb_attribute)
 
-      array = Factory.integer(3).times.map{ values.choice }
+      array = Factory.integer(3).times.map{ values.sample }
       record.json_attribute  = JSON.dump(array)
       record.jsonb_attribute = JSON.dump(array)
       assert_nothing_raised{ record.save! }
@@ -71,7 +71,7 @@ module Ardb::PgJson
       assert_equal array, JSON.load(record.json_attribute)
       assert_equal array, JSON.load(record.jsonb_attribute)
 
-      value = values.choice
+      value = values.sample
       record.json_attribute  = JSON.dump(value)
       record.jsonb_attribute = JSON.dump(value)
       assert_nothing_raised{ record.save! }

--- a/test/unit/ardb_tests.rb
+++ b/test/unit/ardb_tests.rb
@@ -55,7 +55,7 @@ module Ardb
       end
 
       ENV['ARDB_DB_FILE']   = 'test/support/require_test_db_file'
-      @ardb_config.adapter  = Adapter::VALID_ADAPTERS.choice
+      @ardb_config.adapter  = Adapter::VALID_ADAPTERS.sample
       @ardb_config.database = Factory.string
 
       @ar_establish_connection_called_with = nil
@@ -220,7 +220,7 @@ module Ardb
       new_migrations_path = "/#{Factory.path}"
       new_schema_path     = "/#{Factory.path}"
 
-      subject.root_path       = [Factory.path, nil].choice
+      subject.root_path       = [Factory.path, nil].sample
       subject.migrations_path = new_migrations_path
       subject.schema_path     = new_schema_path
       assert_equal new_migrations_path, subject.migrations_path
@@ -236,7 +236,7 @@ module Ardb
 
     should "know its activerecord connection hash" do
       attrs_and_values = @config_class::ACTIVERECORD_ATTRS.map do |attr_name|
-        value = [Factory.string,  nil].choice
+        value = [Factory.string,  nil].sample
         subject.send("#{attr_name}=", value)
         [attr_name.to_s, value] if !value.nil?
       end.compact
@@ -259,7 +259,7 @@ module Ardb
       subject.schema_format = Factory.string
       assert_raises(ConfigurationError){ subject.validate! }
 
-      subject.schema_format = @config_class::VALID_SCHEMA_FORMATS.choice
+      subject.schema_format = @config_class::VALID_SCHEMA_FORMATS.sample
       assert_nothing_raised{ subject.validate! }
     end
 
@@ -296,7 +296,7 @@ module Ardb
         ['sqlite',     Ardb::Adapter::Sqlite],
         ['postgresql', Ardb::Adapter::Postgresql],
         ['mysql',      Ardb::Adapter::Mysql]
-      ].choice
+      ].sample
       @config.adapter = adapter_key
 
       adapter = subject.new(@config)

--- a/test/unit/cli_tests.rb
+++ b/test/unit/cli_tests.rb
@@ -236,7 +236,7 @@ class Ardb::CLI
     end
 
     should "raise a help exit if its argv is empty" do
-      cmd = @command_class.new([nil, ''].choice)
+      cmd = @command_class.new([nil, ''].sample)
       assert_raises(Ardb::CLIRB::HelpExit){ cmd.new([]).run }
     end
 

--- a/test/unit/has_slug_tests.rb
+++ b/test/unit/has_slug_tests.rb
@@ -66,7 +66,7 @@ module Ardb::HasSlug
     end
 
     should "allow customizing the has slug config using `has_slug`" do
-      separator        = NON_WORD_CHARS.choice
+      separator        = NON_WORD_CHARS.sample
       allow_underscore = Factory.boolean
       subject.has_slug({
         :attribute         => @slug_attribute,
@@ -145,8 +145,8 @@ module Ardb::HasSlug
   class InitTests < UnitTests
     desc "when init"
     setup do
-      @preprocessor      = [:downcase, :upcase, :capitalize].choice
-      @separator         = NON_WORD_CHARS.choice
+      @preprocessor      = [:downcase, :upcase, :capitalize].sample
+      @separator         = NON_WORD_CHARS.sample
       @allow_underscores = Factory.boolean
 
       @record_class.has_slug(:source => @source_attribute)
@@ -272,8 +272,8 @@ module Ardb::HasSlug
 
     should "turn invalid chars into a separator" do
       string = Factory.integer(3).times.map do
-        "#{Factory.string(3)}#{NON_WORD_CHARS.choice}#{Factory.string(3)}"
-      end.join(NON_WORD_CHARS.choice)
+        "#{Factory.string(3)}#{NON_WORD_CHARS.sample}#{Factory.string(3)}"
+      end.join(NON_WORD_CHARS.sample)
       assert_equal string.gsub(/[^\w]+/, '-'), subject.new(string, @args)
     end
 
@@ -288,9 +288,9 @@ module Ardb::HasSlug
     end
 
     should "allow passing a custom separator" do
-      separator = NON_WORD_CHARS.choice
+      separator = NON_WORD_CHARS.sample
 
-      invalid_char = (NON_WORD_CHARS - [separator]).choice
+      invalid_char = (NON_WORD_CHARS - [separator]).sample
       string = "#{Factory.string}#{invalid_char}#{Factory.string}"
       exp = string.gsub(/[^\w]+/, separator)
       assert_equal exp, subject.new(string, @args.merge(:separator => separator))
@@ -321,7 +321,7 @@ module Ardb::HasSlug
       assert_equal string.gsub(/-{2,}/, '-'), subject.new(string, @args)
 
       # remove separators that were added from changing invalid chars
-      invalid_chars = (Factory.integer(3) + 1).times.map{ NON_WORD_CHARS.choice }.join
+      invalid_chars = (Factory.integer(3) + 1).times.map{ NON_WORD_CHARS.sample }.join
       string = "#{Factory.string}#{invalid_chars}#{Factory.string}"
       assert_equal string.gsub(/[^\w]+/, '-'), subject.new(string, @args)
     end
@@ -331,7 +331,7 @@ module Ardb::HasSlug
       assert_equal string[1..-2], subject.new(string, @args)
 
       # remove separators that were added from changing invalid chars
-      invalid_char = NON_WORD_CHARS.choice
+      invalid_char = NON_WORD_CHARS.sample
       string = "#{invalid_char}#{Factory.string}-#{Factory.string}#{invalid_char}"
       assert_equal string[1..-2], subject.new(string, @args)
     end

--- a/test/unit/migration_tests.rb
+++ b/test/unit/migration_tests.rb
@@ -64,7 +64,7 @@ class Ardb::Migration
 
     should "complain if no identifier is provided" do
       assert_raises(NoIdentifierError) do
-        @migration_class.new([nil, ''].choice)
+        @migration_class.new([nil, ''].sample)
       end
     end
 

--- a/test/unit/record_spy_tests.rb
+++ b/test/unit/record_spy_tests.rb
@@ -177,7 +177,7 @@ module Ardb::RecordSpy
       assert_respond_to "around_#{name}", subject
       assert_respond_to "after_#{name}",  subject
 
-      callback_name = ["before_#{name}", "around_#{name}", "after_#{name}"].choice
+      callback_name = ["before_#{name}", "around_#{name}", "after_#{name}"].sample
       method_name = Factory.string
       subject.send(callback_name, method_name)
       callback = subject.callbacks.last

--- a/test/unit/use_db_default_tests.rb
+++ b/test/unit/use_db_default_tests.rb
@@ -71,13 +71,13 @@ module Ardb::UseDbDefault
 
       # simulate activerecords `@attributes` hash
       @original_attrs = @attr_names.inject({}) do |h, n|
-        h.merge!(n => [nil, Factory.string, Factory.integer].choice)
+        h.merge!(n => [nil, Factory.string, Factory.integer].sample)
       end
       @original_attrs.merge!(Factory.string => Factory.string)
       @record.attributes = @original_attrs.dup
 
       # randomly pick a use-db-default attribute to be changed
-      @record.changed_use_db_default_attrs = [@attr_names.choice]
+      @record.changed_use_db_default_attrs = [@attr_names.sample]
       @unchanged_attr_names = @attr_names - @record.changed_use_db_default_attrs
 
       # we should always get the record we just inserted back


### PR DESCRIPTION
This switches to using `sample` instead of `choice` but backfills
`sample` so it works in ruby 1.8.7. This is part of making sure the
gem works for newer versions of ruby. This allows the test suite to
be run on newer versions of ruby which can be used to tell if the
gem is compatible with the version or not.

@kellyredding - Ready for review.