### PR TITLE
Don't init ardb until a command is run

### DIFF
--- a/lib/ardb.rb
+++ b/lib/ardb.rb
@@ -26,11 +26,7 @@ module Ardb
 
     # setup AR
     ActiveRecord::Base.logger = self.config.logger
-    if establish_connection
-      ActiveRecord::Base.establish_connection(
-        self.config.activerecord_connect_hash
-      )
-    end
+    self.adapter.connect_db if establish_connection
   end
 
   def self.escape_like_pattern(pattern, escape_char = nil)

--- a/lib/ardb/adapter/base.rb
+++ b/lib/ardb/adapter/base.rb
@@ -41,7 +41,10 @@ module Ardb::Adapter
     def drop_tables(*args); raise NotImplementedError; end
 
     def connect_db
-      ActiveRecord::Base.connection
+      ActiveRecord::Base.establish_connection(self.connect_hash)
+      # checkout a connection to ensure we can connect to the DB, we don't do
+      # anything with the connection and immediately check it back in
+      ActiveRecord::Base.connection_pool.with_connection{ }
     end
 
     def migrate_db


### PR DESCRIPTION
This changes the cli commands to not init ardb as part of the main
cli and instead wait and let the commands init it themselves. This
makes it so the cli will not error about being unable to load an
ardb db file when using `--help` or `--version`. The cli will still
error if an actual command is used that then initialized ardb.

This also has other benefits of letting the commands customize how
they want to init ardb (establish a connection or not). The
connect, drop and migrate commands all want to establish a
connection because they can assume the db should already exist. The
create command doesn't want to establish a connection ecause it
assumes the db doesn't already exist. Similarly, the generate
migration command doesn't need to establish a connection to a db
to generate a migration file.

This also changes the `connect_db` method on adapters to actually
handle connecting to the db using activerecord's
`establish_connection`. This allows the cli connect command to init
ardb without establishing a connection and then manually try to
connect using the `connect_db` method. As part of this, I changed
the ardb init logic to call the `connect_db` method as well.
Finally, the `connect_db` uses activerecord's connection pool and
`with_connection` helper to ensure that it can checkout a
connection. This was previously done by using the `connection`
method but this has the side-effect of checking out a connection
and never returning it (unless the clear active connections
method is called). By using the `with_connection` method it
provides the same functionality but checks the connection back
into the pool.

Closes #101 

@kellyredding - Ready for review.