### PR TITLE
Pass `Config` to `Migration` instead of using `Ardb.config`

### DIFF
--- a/lib/ardb/cli/commands.rb
+++ b/lib/ardb/cli/commands.rb
@@ -191,12 +191,12 @@ class Ardb::CLI
 
     def run(argv, *args)
       super
-
       begin
         Ardb.init(false)
         require 'ardb/migration'
-        path = Ardb::Migration.new(@clirb.args.first).save!.file_path
-        @stdout.puts "generated #{path}"
+        migration = Ardb::Migration.new(Ardb.config, @clirb.args.first)
+        migration.save!
+        @stdout.puts "generated #{migration.file_path}"
       rescue Ardb::Migration::NoIdentifierError => exception
         error = ArgumentError.new("MIGRATION-NAME must be provided")
         error.set_backtrace(exception.backtrace)

--- a/lib/ardb/migration.rb
+++ b/lib/ardb/migration.rb
@@ -4,16 +4,18 @@ module Ardb
 
   class Migration
 
-    attr_reader :identifier, :class_name, :file_name, :file_path
-    attr_reader :source
+    attr_reader :migrations_path, :identifier
+    attr_reader :class_name, :file_name, :file_path, :source
 
-    def initialize(identifier)
+    def initialize(ardb_config, identifier)
       raise NoIdentifierError if identifier.to_s.empty?
 
-      @identifier = identifier
+      @migrations_path = ardb_config.migrations_path
+      @identifier      = identifier
+
       @class_name = @identifier.classify.pluralize
       @file_name  = get_file_name(@identifier)
-      @file_path  = File.join(Ardb.config.migrations_path, "#{@file_name}.rb")
+      @file_path  = File.join(self.migrations_path, "#{@file_name}.rb")
 
       @source = "require 'ardb/migration_helpers'\n\n" \
                 "class #{@class_name} < ActiveRecord::Migration\n" \
@@ -24,7 +26,7 @@ module Ardb
     end
 
     def save!
-      FileUtils.mkdir_p Ardb.config.migrations_path
+      FileUtils.mkdir_p self.migrations_path
       File.open(self.file_path, 'w'){ |f| f.write(self.source) }
       self
     end

--- a/test/unit/cli_tests.rb
+++ b/test/unit/cli_tests.rb
@@ -526,6 +526,7 @@ class Ardb::CLI
       subject.run([@identifier], @stdout, @stderr)
 
       assert_equal [false],     @ardb_init_called_with
+      assert_equal Ardb.config, @migration_spy.ardb_config
       assert_equal @identifier, @migration_spy.identifier
       assert_true @migration_spy.save_called
 
@@ -629,10 +630,11 @@ class Ardb::CLI
   end
 
   class MigrationSpy
-    attr_reader :identifier, :file_path, :save_called
+    attr_reader :ardb_config, :identifier, :file_path, :save_called
 
-    def initialize(*args)
-      @identifier  = args.first
+    def initialize(ardb_config, identifier)
+      @ardb_config = ardb_config
+      @identifier  = identifier
       @file_path   = Factory.path
       @save_called = false
     end


### PR DESCRIPTION
This switches to passing a `Config` to the `Migration` class
isntead of it referencing the global `Ardb.config`. This is to
decouple it and make it so its tests don't require ardb to be
configured and init. This doesn't change the migration class's
functionality.

This also updates the cli generate migration command to use
`Ardb.config` when it builds a `Migration`. This keeps the cli
working as it previously did.

@kellyredding - Ready for review.