### PR TITLE
cli: update valid commands to allow custom CLIRB build procs

### DIFF
--- a/ardb.gemspec
+++ b/ardb.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency("assert", ["~> 2.16.0"])
+  gem.add_development_dependency("assert", ["~> 2.16.1"])
 
   gem.add_dependency('activerecord',  ["~> 3.2"])
   gem.add_dependency('activesupport', ["~> 3.2"])

--- a/lib/ardb/cli/commands.rb
+++ b/lib/ardb/cli/commands.rb
@@ -43,8 +43,8 @@ class Ardb::CLI
 
     module InstanceMethods
 
-      def initialize
-        @clirb = CLIRB.new
+      def initialize(&clirb_build)
+        @clirb = CLIRB.new(&clirb_build)
       end
 
       def clirb; @clirb; end

--- a/test/unit/cli_tests.rb
+++ b/test/unit/cli_tests.rb
@@ -274,6 +274,14 @@ class Ardb::CLI
       assert_equal argv, subject.clirb.args
     end
 
+    should "take custom CLIRB build procs" do
+      cmd = @command_class.new do
+        option 'test', 'testing', :abbrev => 't'
+      end
+      cmd.run(['-t'], @stdout, @stderr)
+      assert_true cmd.clirb.opts['test']
+    end
+
     should "default its summary" do
       assert_equal '', subject.summary
     end


### PR DESCRIPTION
This allows individual commands to take individual options.  There
is no immediate need for this behavior but it was added to GGem (see
GGem's PR 35).  Ardb's command handling is modeled after GGem so this
is added to keep things consistent.

Note: this also updates to the latest Assert patch.  This is just
to keep up with the latest stuff.

See https://github.com/redding/ggem/pull/35 for reference.

@jcredding ready for review.