### PR TITLE
Add nice error when ardb can't require a db file on init

### DIFF
--- a/lib/ardb/cli/commands.rb
+++ b/lib/ardb/cli/commands.rb
@@ -69,8 +69,8 @@ class Ardb::CLI
     def run(argv, *args)
       super
 
+      Ardb.init(false)
       begin
-        Ardb.init(false)
         Ardb.adapter.connect_db
         @stdout.puts "connected to #{Ardb.config.adapter} db `#{Ardb.config.database}`"
       rescue StandardError => e
@@ -101,8 +101,8 @@ class Ardb::CLI
     def run(argv, *args)
       super
 
+      Ardb.init(false)
       begin
-        Ardb.init(false)
         Ardb.adapter.create_db
         @stdout.puts "created #{Ardb.config.adapter} db `#{Ardb.config.database}`"
       rescue StandardError => e
@@ -131,8 +131,8 @@ class Ardb::CLI
     def run(argv, *args)
       super
 
+      Ardb.init(true)
       begin
-        Ardb.init(true)
         Ardb.adapter.drop_db
         @stdout.puts "dropped #{Ardb.config.adapter} db `#{Ardb.config.database}`"
       rescue StandardError => e
@@ -161,8 +161,8 @@ class Ardb::CLI
     def run(argv, *args)
       super
 
+      Ardb.init(true)
       begin
-        Ardb.init(true)
         Ardb.adapter.migrate_db
         Ardb.adapter.dump_schema unless ENV['ARDB_MIGRATE_NO_SCHEMA']
       rescue StandardError => e
@@ -191,8 +191,9 @@ class Ardb::CLI
 
     def run(argv, *args)
       super
+
+      Ardb.init(false)
       begin
-        Ardb.init(false)
         require 'ardb/migration'
         migration = Ardb::Migration.new(Ardb.config, @clirb.args.first)
         migration.save!

--- a/test/unit/ardb_tests.rb
+++ b/test/unit/ardb_tests.rb
@@ -86,6 +86,14 @@ module Ardb
       assert_false require(File.expand_path(ENV['ARDB_DB_FILE'], ENV['PWD']))
     end
 
+    should "raise an invalid db file error when it can't require it" do
+      ENV['ARDB_DB_FILE'] = Factory.file_path
+      error = assert_raises(InvalidDBFileError){ subject.init }
+      exp = "can't require `#{ENV['ARDB_DB_FILE']}`, check that the " \
+            "ARDB_DB_FILE env var is set to the file path of your db file"
+      assert_equal exp, error.message
+    end
+
     should "validate its config" do
       validate_called = false
       Assert.stub(@ardb_config, :validate!){ validate_called = true }

--- a/test/unit/cli_tests.rb
+++ b/test/unit/cli_tests.rb
@@ -1,6 +1,7 @@
 require 'assert'
 require 'ardb/cli'
 
+require 'ardb'
 require 'ardb/adapter_spy'
 require 'ardb/migration'
 
@@ -325,7 +326,7 @@ class Ardb::CLI
     should "output any errors and raise an exit error when run" do
       err = StandardError.new(Factory.string)
       err.set_backtrace(Factory.integer(3).times.map{ Factory.path })
-      Assert.stub(Ardb, :init){ raise err }
+      Assert.stub(@adapter_spy, :connect_db){ raise err }
 
       assert_raises(CommandExitError){ subject.run([], @stdout, @stderr) }
       err_output = @stderr.read
@@ -464,7 +465,7 @@ class Ardb::CLI
       assert_equal exp, subject.help
     end
 
-    should "init ardb and migrate the db, dump schema when run" do
+    should "init ardb, migrate the db and dump the schema when run" do
       subject.run([], @stdout, @stderr)
 
       assert_equal [true], @ardb_init_called_with
@@ -472,7 +473,7 @@ class Ardb::CLI
       assert_true @adapter_spy.dump_schema_called?
     end
 
-    should "init ardb and only migrate when run with no schema dump env var set" do
+    should "only init ardb and migrate when run with no schema dump env var set" do
       ENV['ARDB_MIGRATE_NO_SCHEMA'] = 'yes'
       subject.run([], @stdout, @stderr)
 
@@ -484,7 +485,7 @@ class Ardb::CLI
     should "output any errors and raise an exit error when run" do
       err = StandardError.new(Factory.string)
       err.set_backtrace(Factory.integer(3).times.map{ Factory.path })
-      Assert.stub(Ardb, :init){ raise err }
+      Assert.stub(@adapter_spy, :migrate_db){ raise err }
 
       assert_raises(CommandExitError){ subject.run([], @stdout, @stderr) }
       err_output = @stderr.read


### PR DESCRIPTION
This updates ardb to throw a nice error when it can't require the
db file specified by the `ARDB_DB_FILE` env var. This is to help
users out when using hte CLI or ardb in their code.

This also updates the cli commands to specially handle this error
by moving `Ardb.init` out of their begin rescue blocks. This makes
it so the error doesn't get caught by the commands custom error
handling. Each command does custom error handling to better explain
that the action they were trying to perform couldn't be done. The
invalid db file error would be stomped by this error handling so
users wouldn't get the nice error message. By moving it out, the
inavlid db file error is handled by the CLI which displays it to
the user. Any errors thrown by `Ardb.init` should be handled this
way because they aren't directly related to the action being
performed and they have error messages that are designed to help
users.

Closes #100

@kellyredding - Ready for review.

![screen shot 2016-06-02 at 12 19 27 pm](https://cloud.githubusercontent.com/assets/85966/15754589/5c839e08-28be-11e6-90f2-80c910a34c94.png)

