### PR TITLE
Update `escape_like_pattern` to always return the pattern string

### DIFF
--- a/lib/ardb/adapter/base.rb
+++ b/lib/ardb/adapter/base.rb
@@ -30,6 +30,7 @@ module Ardb::Adapter
       pattern.gsub!(escape_char){ escape_char * 2 }
       # don't allow custom wildcards
       pattern.gsub!(/%|_/){ |wildcard_char| "#{escape_char}#{wildcard_char}" }
+      pattern
     end
 
     def foreign_key_add_sql(*args);  raise NotImplementedError; end

--- a/test/unit/adapter/base_tests.rb
+++ b/test/unit/adapter/base_tests.rb
@@ -51,6 +51,9 @@ class Ardb::Adapter::Base
                 "#{Factory.string}"
       exp = pattern.gsub("\\"){ "\\\\" }.gsub('%', "\\%").gsub('_', "\\_")
       assert_equal exp, subject.escape_like_pattern(pattern)
+
+      pattern = Factory.string
+      assert_equal pattern, subject.escape_like_pattern(pattern)
     end
 
     should "allow using a custom escape char when escaping like patterns" do


### PR DESCRIPTION
This updates the `escape_like_pattern` method on the adapters to
always ensure it returns the pattern that was being escaped. The
`gsub!` method will only return the string if it matched, otherwise
it returns `nil`. This caused tools using `escape_like_pattern` to
not work if nothing needed to be escaped. This was missed because
the tests only tested how it behaved with a string that the gsubs
matched.

@kellyredding - Ready for review.