### PR TITLE
Raise not initialized error when using `adapter` before `init`

### DIFF
--- a/test/support/postgresql/setup_test_db.rb
+++ b/test/support/postgresql/setup_test_db.rb
@@ -31,6 +31,7 @@ class PostgresqlDbTests < Assert::Context
     Ardb.adapter.connect_db
   end
   teardown do
+    Ardb.reset_adapter
     ActiveRecord::Base.logger = @orig_ar_logger
     ENV['ARDB_DB_FILE']       = @orig_env_ardb_db_file
   end

--- a/test/unit/ardb_tests.rb
+++ b/test/unit/ardb_tests.rb
@@ -14,10 +14,13 @@ module Ardb
     setup do
       @module = Ardb
     end
+    teardown do
+      @module.reset_adapter
+    end
     subject{ @module }
 
-    should have_imeths :config, :configure, :adapter, :init
-    should have_imeths :escape_like_pattern
+    should have_imeths :config, :configure, :adapter, :reset_adapter
+    should have_imeths :init, :escape_like_pattern
 
     should "default the db file env var" do
       assert_equal 'config/db', ENV['ARDB_DB_FILE']
@@ -120,6 +123,16 @@ module Ardb
 
       subject.init(false)
       assert_equal 2, @ardb_adapter.connect_db_called_count
+    end
+
+    should "raise a not initialized error using its adapter before init" do
+      subject.reset_adapter
+      assert_raises(NotInitializedError){ subject.adapter }
+      assert_raises(NotInitializedError){ subject.escape_like_pattern(Factory.string) }
+
+      subject.init
+      assert_nothing_raised{ subject.adapter }
+      assert_nothing_raised{ subject.escape_like_pattern(Factory.string) }
     end
 
   end


### PR DESCRIPTION
This updates ardb to raise a not initialized error when its adapter
is used before it has been `init`. This is to avoid no method
errors happening because the `adapter` is `nil`. Instead this
throws a nice error that explains ardb hasn't been init yet.

This also adds `reset_adapter` method which allows setting the
adapter back to `nil`. This was needed to reliably test that it
would throw the not initialized error. Ardb has system tests that
init ardb so its adapter can be set depending on the order the
tests are run. This updates the tests to reset the adapter to
help ensure we aren't depending on the global state in our tests.

This also updates a couple locations that change exceptions
backtraces to avoid them pointing to the internals of ardb. They
previously used `tap` to one-line this operation but blocks change
ruby's `caller` so the backtrace wasn't the caller of the method
but the caller of `tap` (which pointed to ardb internals). This
switches to setting the backtrace on its own line outside of a
block to ensure `caller` is the methods caller. I noticed this
while testing this with a real use-case of ardb not being init
before using adapter and saw the wrong backtrace.

Closes #116 

@kellyredding - Ready for review. I thought I would handle this with a null adapter but this gets the same results with less code. The migration doesn't use the adapter and the migration helpers manually build an ardb adapter. We already put in friendly errors if we can't build an adapter because the config is invalid so no changes were needed. All of the cli commands use `Ardb.adapter` and `Ardb.init` so they should be covered as well.