### PR TITLE
move configured db name validation to Postgres adapter

### DIFF
--- a/ardb.gemspec
+++ b/ardb.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = "~> 2.4"
 
-  gem.add_development_dependency("assert", ["~> 2.18.0"])
+  gem.add_development_dependency("assert", ["~> 2.18.1"])
 
   gem.add_dependency("activerecord",  ["~> 5.0"])
   gem.add_dependency("activesupport", ["~> 5.0"])

--- a/lib/ardb.rb
+++ b/lib/ardb.rb
@@ -121,11 +121,6 @@ module Ardb
         raise ConfigurationError, "an adapter and database must be provided"
       end
 
-      if self.database =~ /\W/
-        raise ConfigurationError, "database value must not contain non-word "\
-                                  "characters. Given: #{self.database.inspect}."
-      end
-
       if !VALID_SCHEMA_FORMATS.include?(self.schema_format)
         raise ConfigurationError, "schema format must be one of: " \
                                   "#{VALID_SCHEMA_FORMATS.join(", ")}"

--- a/lib/ardb/adapter/base.rb
+++ b/lib/ardb/adapter/base.rb
@@ -7,6 +7,7 @@ module Ardb::Adapter
 
     def initialize(config)
       @config = config
+      validate!
     end
 
     def connect_hash;    self.config.activerecord_connect_hash; end
@@ -108,6 +109,10 @@ module Ardb::Adapter
     end
 
     private
+
+    def validate!
+      # override as needed
+    end
 
     def migration_context
       ActiveRecord::MigrationContext.new(migrations_path)

--- a/lib/ardb/adapter/postgresql.rb
+++ b/lib/ardb/adapter/postgresql.rb
@@ -60,6 +60,16 @@ module Ardb::Adapter
 
     private
 
+    def validate!
+      if self.database =~ /\W/
+        raise(
+          Ardb::ConfigurationError,
+          "database value must not contain non-word characters. "\
+          "Given: #{self.database.inspect}."
+        )
+      end
+    end
+
     def env_var_hash
       @env_var_hash ||= {
         "PGHOST"     => self.connect_hash["host"],

--- a/test/unit/adapter/postgresql_tests.rb
+++ b/test/unit/adapter/postgresql_tests.rb
@@ -21,6 +21,13 @@ class Ardb::Adapter::Postgresql
       })
       assert_equal exp, subject.public_connect_hash
     end
+
+    should "complain if given a database name with non-word characters" do
+      @config.database = "#{Factory.string}-#{Factory.string}"
+      assert_raises(Ardb::ConfigurationError){
+        Ardb::Adapter::Postgresql.new(@config)
+      }
+    end
   end
 
   class SQLSchemaTests < UnitTests

--- a/test/unit/ardb_tests.rb
+++ b/test/unit/ardb_tests.rb
@@ -262,9 +262,6 @@ module Ardb
       subject.database = nil
       assert_raises(ConfigurationError){ subject.validate! }
 
-      subject.database = "#{Factory.string}-#{Factory.string}"
-      assert_raises(ConfigurationError){ subject.validate! }
-
       subject.database      = Factory.string
       subject.schema_format = Factory.string
       assert_raises(ConfigurationError){ subject.validate! }


### PR DESCRIPTION
This validation isn't appropriate for all db engines. Specifically
Sqlite uses db names such as `path/to/mydb.sqlite` or `:memory:`.
This validation is really only needed for Postgres as far as I've
seen.

Thanks to @jcredding for noticing this in a real-world use case.