### PR TITLE
Allow configuring `ActiveRecord::Base.default_timezone`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,18 +41,19 @@ require "ardb"
 
 # This Ardb configuration matches Rails's settings.
 Ardb.configure do |c|
-  rails_db_config = Rails.application.config_for("database")
-  c.root_path     = Rails.root
-  c.logger        = Rails.logger
-  c.schema_format = Rails.application.config.active_record.schema_format || :ruby
-  c.adapter       = rails_db_config["adapter"]
-  c.host          = rails_db_config["host"]
-  c.port          = rails_db_config["port"]
-  c.username      = rails_db_config["username"]
-  c.password      = rails_db_config["password"]
-  c.database      = rails_db_config["database"]
-  c.encoding      = rails_db_config["encoding"]
-  c.min_messages  = rails_db_config["min_messages"]
+  rails_db_config    = Rails.application.config_for("database")
+  c.root_path        = Rails.root
+  c.logger           = Rails.logger
+  c.schema_format    = Rails.application.config.active_record.schema_format || :ruby
+  c.default_timezone = :utc
+  c.adapter          = rails_db_config["adapter"]
+  c.host             = rails_db_config["host"]
+  c.port             = rails_db_config["port"]
+  c.username         = rails_db_config["username"]
+  c.password         = rails_db_config["password"]
+  c.database         = rails_db_config["database"]
+  c.encoding         = rails_db_config["encoding"]
+  c.min_messages     = rails_db_config["min_messages"]
 
   c.migrations_path = "db/migrate"
   c.schema_path = "db/schema"

--- a/lib/ardb.rb
+++ b/lib/ardb.rb
@@ -33,6 +33,7 @@ module Ardb
     @adapter = Adapter.new(self.config)
 
     # setup AR
+    ActiveRecord::Base.default_timezone = self.config.default_timezone
     ActiveRecord::Base.logger = self.config.logger
     self.adapter.connect_db if establish_connection
   end
@@ -81,16 +82,17 @@ module Ardb
     VALID_SCHEMA_FORMATS    = [RUBY_SCHEMA_FORMAT, SQL_SCHEMA_FORMAT].freeze
 
     attr_accessor(*ACTIVERECORD_ATTRS)
-    attr_accessor :logger, :root_path
+    attr_accessor :default_timezone, :logger, :root_path
     attr_reader :schema_format
     attr_writer :migrations_path, :schema_path
 
     def initialize
-      @logger          = Logger.new(STDOUT)
-      @root_path       = ENV["PWD"]
-      @migrations_path = DEFAULT_MIGRATIONS_PATH
-      @schema_path     = DEFAULT_SCHEMA_PATH
-      @schema_format   = RUBY_SCHEMA_FORMAT
+      @default_timezone = :utc
+      @logger           = Logger.new(STDOUT)
+      @root_path        = ENV["PWD"]
+      @migrations_path  = DEFAULT_MIGRATIONS_PATH
+      @schema_path      = DEFAULT_SCHEMA_PATH
+      @schema_format    = RUBY_SCHEMA_FORMAT
     end
 
     def migrations_path
@@ -132,6 +134,7 @@ module Ardb
     def ==(other)
       if other.kind_of?(self.class)
         self.activerecord_connect_hash == other.activerecord_connect_hash &&
+        self.default_timezone          == other.default_timezone          &&
         self.logger                    == other.logger                    &&
         self.root_path                 == other.root_path                 &&
         self.schema_format             == other.schema_format             &&
@@ -192,5 +195,4 @@ module Ardb
       set_backtrace(backtrace)
     end
   end
-
 end

--- a/test/unit/ardb_tests.rb
+++ b/test/unit/ardb_tests.rb
@@ -110,6 +110,13 @@ module Ardb
       assert_same @ardb_adapter, subject.adapter
     end
 
+    should "set ActiveRecord::Base attributes" do
+      subject.init
+
+      assert_equal subject.config.logger, ActiveRecord::Base.logger
+      assert_equal subject.config.default_timezone, ActiveRecord::Base.default_timezone
+    end
+
     should "optionally establish an AR connection" do
       assert_nil @ardb_adapter
       subject.init
@@ -193,12 +200,13 @@ module Ardb
     subject{ @config }
 
     should have_accessors *Ardb::Config::ACTIVERECORD_ATTRS
-    should have_accessors :logger, :root_path
+    should have_accessors :default_timezone, :logger, :root_path
     should have_readers :schema_format
     should have_writers :migrations_path, :schema_path
     should have_imeths :activerecord_connect_hash, :validate!
 
     should "default its attributs" do
+      assert_equal :utc, subject.default_timezone
       assert_instance_of Logger, subject.logger
       assert_equal ENV["PWD"], subject.root_path
       exp = File.expand_path(@config_class::DEFAULT_MIGRATIONS_PATH, subject.root_path)
@@ -272,6 +280,7 @@ module Ardb
 
     should "know if its equal to another config" do
       attrs = @config_class::ACTIVERECORD_ATTRS + [
+        :default_timezone,
         :logger,
         :root_path,
         :schema_format,


### PR DESCRIPTION
This updates the `Ardb::Config` to allow setting a
`default_timezone` which is then used to set
`ActiveRecord::Base.default_timezone`. This allows setting this
with the rest of the ActiveRecord configuration and avoids having
to manually set it separately.