### PR TITLE
Update "require autoloaded" script to support ActiveRecord 6.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,24 @@
 source "https://rubygems.org"
 
-ruby "~> 2.4"
+ruby "~> 2.5"
 
 gemspec
+
+# Uncomment one of these and run:
+#
+#     bundle update activerecord activesupport
+#
+# to test a specific version.
+#
+# Rails 6.1
+gem "activerecord",  "~> 6.1"
+gem "activesupport", "~> 6.1"
+# Rails 6.0
+# gem "activerecord",  "~> 6.0.3"
+# gem "activesupport", "~> 6.0.3"
+# Rails 5.2
+# gem "activerecord",  "~> 5.2.4"
+# gem "activesupport", "~> 5.2.4"
 
 gem "pg",  "~> 1.1.4"
 gem "pry", "~> 0.12.2"

--- a/ardb.gemspec
+++ b/ardb.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = "~> 2.4"
+  gem.required_ruby_version = "~> 2.5"
 
-  gem.add_development_dependency("assert", ["~> 2.18.1"])
+  gem.add_development_dependency("assert", ["~> 2.19.0"])
 
   gem.add_dependency("activerecord",  ["> 5.0", "< 7.0"])
   gem.add_dependency("activesupport", ["> 5.0", "< 7.0"])

--- a/lib/ardb/require_autoloaded_active_record_files.rb
+++ b/lib/ardb/require_autoloaded_active_record_files.rb
@@ -12,7 +12,71 @@
 # For compatibility, we require active record first
 require "active_record"
 
-if ActiveRecord.version.segments.first == 6
+if (
+  ActiveRecord.version.segments[0] == 6 &&
+  ActiveRecord.version.segments[1] > 0
+)
+  require "active_record/aggregations"
+  require "active_record/association_relation"
+  require "active_record/associations"
+  require "active_record/associations/alias_tracker"
+  require "active_record/associations/association"
+  require "active_record/associations/association_scope"
+  require "active_record/associations/belongs_to_association"
+  require "active_record/associations/belongs_to_polymorphic_association"
+  require "active_record/associations/builder/association"
+  require "active_record/associations/builder/belongs_to"
+  require "active_record/associations/builder/collection_association"
+  require "active_record/associations/builder/has_and_belongs_to_many"
+  require "active_record/associations/builder/has_many"
+  require "active_record/associations/builder/has_one"
+  require "active_record/associations/collection_association"
+  require "active_record/associations/collection_proxy"
+  require "active_record/associations/foreign_association"
+  require "active_record/associations/has_many_association"
+  require "active_record/associations/has_many_through_association"
+  require "active_record/associations/has_one_association"
+  require "active_record/associations/has_one_through_association"
+  require "active_record/associations/join_dependency"
+  require "active_record/associations/join_dependency/join_association"
+  require "active_record/associations/join_dependency/join_base"
+  require "active_record/associations/preloader"
+  require "active_record/associations/preloader/association"
+  require "active_record/associations/preloader/through_association"
+  require "active_record/attribute_assignment"
+  require "active_record/attribute_methods/before_type_cast"
+  require "active_record/attribute_methods/dirty"
+  require "active_record/attribute_methods/primary_key"
+  require "active_record/attribute_methods/query"
+  require "active_record/attribute_methods/read"
+  require "active_record/attribute_methods/serialization"
+  require "active_record/attribute_methods/time_zone_conversion"
+  require "active_record/attribute_methods/write"
+  require "active_record/attributes"
+  require "active_record/autosave_association"
+  require "active_record/base"
+  require "active_record/coders/json"
+  require "active_record/internal_metadata"
+  require "active_record/legacy_yaml_adapter"
+  require "active_record/middleware/database_selector"
+  require "active_record/null_relation"
+  require "active_record/relation/predicate_builder"
+  require "active_record/relation/record_fetch_warning"
+  require "active_record/result"
+  require "active_record/runtime_registry"
+  require "active_record/statement_cache"
+  require "active_record/table_metadata"
+  require "active_record/tasks/database_tasks"
+  require "active_record/tasks/mysql_database_tasks"
+  require "active_record/tasks/postgresql_database_tasks"
+  require "active_record/tasks/sqlite_database_tasks"
+  require "arel/collectors/bind"
+  require "arel/collectors/composite"
+  require "arel/collectors/substitute_binds"
+elsif (
+  ActiveRecord.version.segments[0] == 6 &&
+  ActiveRecord.version.segments[1] == 0
+)
   require "active_record/advisory_lock_base"
   require "active_record/associations/alias_tracker"
   require "active_record/associations/association"
@@ -51,7 +115,7 @@ if ActiveRecord.version.segments.first == 6
   require "active_record/tasks/mysql_database_tasks"
   require "active_record/tasks/postgresql_database_tasks"
   require "active_record/tasks/sqlite_database_tasks"
-else # ActiveRecord 5
+elsif ActiveRecord.version.segments[0] == 5
   require "active_record/aggregations"
   require "active_record/association_relation"
   require "active_record/associations"
@@ -106,6 +170,11 @@ else # ActiveRecord 5
   require "active_record/tasks/mysql_database_tasks"
   require "active_record/tasks/postgresql_database_tasks"
   require "active_record/tasks/sqlite_database_tasks"
+else
+  raise(
+    "ActiveRecord #{ActiveRecord.version} isn't supported. "\
+    "Switch to 5.X or 6.X"
+  )
 end
 
 # There are also issues with requiring ActiveSupport. This doesn"t require every

--- a/script/determine_autoloaded_active_record_files.rb
+++ b/script/determine_autoloaded_active_record_files.rb
@@ -23,7 +23,9 @@ ignored_regexes = [
   /active_record\/test_case/,
   /active_record\/test_databases/,
   /active_record\/test_fixtures/,
-  /active_record\/coders\/yaml_column/
+  /active_record\/coders\/yaml_column/,
+  # `destroy_association_async_job` requires `ActiveJob` to be required.
+  /active_record\/destroy_association_async_job/,
 ]
 
 Result = Struct.new(:file, :state, :reason)

--- a/test/unit/adapter/base_tests.rb
+++ b/test/unit/adapter/base_tests.rb
@@ -1,8 +1,9 @@
 require "assert"
 require "ardb/adapter/base"
 
+require "active_record/migration"
 require "ardb"
-# This is needed by the schema dumper but it doesn"t handle requiring it so we
+# This is needed by the schema dumper but it doesn't handle requiring it so we
 # have to manually, otherwise this errors when you try to run the adapter base
 # tests by themselves
 require "active_support/core_ext/class/attribute_accessors"


### PR DESCRIPTION
This updates the `require_autoloaded_active_record_files` script
to support ActiveRecord 6.1. This was previously updated to
support ActiveRecord 6.0 but some files have been removed and
added in ActiveRecord 6.1 and the previous didn't work for it.

This also fixes an error that would occur when
`ActiveRecord::MigrationContext` wasn't required before running
the `Adapter::Base` tests. This requires `active_record/migration`
to ensure it's always available.

Finally, this updates to support ruby 2.5 and greater going
forward to match other gems.
